### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
+| < 0.1   | :x:                |
+
+## Reporting a Vulnerability
+
+To report a security vulnerability, please use the [GitHub Security Advisory "Report a Vulnerability" tab](https://github.com/google-labs-code/jules-sdk/security/advisories/new).
+
+> **Note:** This is not an officially supported Google product. This project is not eligible for the [Google Open Source Software Vulnerability Rewards Program](https://bughunters.google.com/open-source-security).


### PR DESCRIPTION
This PR adds a `SECURITY.md` file to the root of the repository. It outlines the supported versions (0.1.x) and provides instructions for reporting security vulnerabilities via GitHub Security Advisories. It also explicitly states that this is not an officially supported Google product and is not eligible for the Google Open Source Software Vulnerability Rewards Program.

---
*PR created automatically by Jules for task [6238741934083768112](https://jules.google.com/task/6238741934083768112) started by @davideast*