### PR TITLE
fix(mcp): handle undefined activities and non-function changeSet

### DIFF
--- a/packages/mcp/src/functions/session-state.ts
+++ b/packages/mcp/src/functions/session-state.ts
@@ -1,23 +1,22 @@
 import type { JulesClient, Activity } from '@google/jules-sdk';
-import type { SessionStateResult, SessionStatus, LastAgentMessage, LastActivity, PendingPlan } from './types.js';
+import type {
+  SessionStateResult,
+  SessionStatus,
+  LastActivity,
+  LastAgentMessage,
+  PendingPlan,
+} from './types.js';
 
-/**
- * States where Jules is actively working and data may be volatile.
- * Includes both API format (SCREAMING_SNAKE_CASE) and SDK format (camelCase).
- */
 const BUSY_STATES = new Set([
   'queued', 'QUEUED',
   'planning', 'PLANNING',
   'inProgress', 'IN_PROGRESS', 'in_progress',
 ]);
-
-/**
- * Failed states in both formats.
- */
 const FAILED_STATES = new Set(['failed', 'FAILED']);
 
 /**
- * Derives a semantic status from the technical session state.
+ * deriveStatus
+ * Maps internal session state to semantic status.
  * - 'busy': Jules is actively working; data is volatile.
  * - 'stable': Work is paused; safe to review.
  * - 'failed': Session encountered an error.
@@ -137,10 +136,13 @@ export async function getSessionState(
 
   const snapshot = await session.snapshot();
 
+  // FIX: Ensure activities is always an array
+  const activities = snapshot.activities ?? [];
+
   const pr = snapshot.pr;
-  const lastActivity = findLastActivity(snapshot.activities);
-  const lastAgentMessage = findLastAgentMessage(snapshot.activities);
-  const pendingPlan = findPendingPlan(snapshot.activities);
+  const lastActivity = findLastActivity(activities);
+  const lastAgentMessage = findLastAgentMessage(activities);
+  const pendingPlan = findPendingPlan(activities);
 
   return {
     id: snapshot.id,
@@ -154,6 +156,3 @@ export async function getSessionState(
     ...(pendingPlan && { pendingPlan }),
   };
 }
-
-
-

--- a/packages/mcp/src/functions/show-diff.ts
+++ b/packages/mcp/src/functions/show-diff.ts
@@ -48,11 +48,14 @@ export async function showDiff(
   await session.activities.hydrate();
   const snapshot = await session.snapshot();
 
+  // FIX: Ensure activities is always an array
+  const activities = snapshot.activities ?? [];
+
   let changeSet: ChangeSetArtifact | undefined;
 
   // If activityId is provided, find the changeSet from that specific activity
   if (activityId) {
-    const activity = snapshot.activities.find(a => a.id === activityId);
+    const activity = activities.find(a => a.id === activityId);
     if (!activity) {
       return {
         sessionId: snapshot.id,
@@ -76,7 +79,10 @@ export async function showDiff(
     }
   } else {
     // Get the changeSet from the snapshot (session outcome)
-    changeSet = snapshot.changeSet() as ChangeSetArtifact | undefined;
+    // FIX: Defensive check for changeSet being a function
+    changeSet = typeof snapshot.changeSet === 'function'
+      ? snapshot.changeSet() as ChangeSetArtifact | undefined
+      : undefined;
   }
 
   if (!changeSet) {

--- a/packages/mcp/tests/functions/null-safety.test.ts
+++ b/packages/mcp/tests/functions/null-safety.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getSessionState } from '../../src/functions/session-state.js';
+import { codeReview } from '../../src/functions/code-review.js';
+import { showDiff } from '../../src/functions/show-diff.js';
+import {
+  createMockClient,
+  createMockSnapshot,
+  mockSessionWithSnapshot,
+} from './helpers.js';
+
+describe('Null Safety & Resilience', () => {
+  let mockClient: ReturnType<typeof createMockClient>;
+
+  beforeEach(() => {
+    mockClient = createMockClient();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Session with undefined activities (new/empty sessions)', () => {
+    it('getSessionState should handle undefined activities gracefully', async () => {
+      const snapshot = createMockSnapshot({
+        id: 'session-new',
+        state: 'queued',
+        title: 'New Session'
+      });
+
+      const mockSession = {
+        snapshot: vi.fn().mockResolvedValue({
+          ...snapshot,
+          activities: undefined
+        }),
+        activities: {
+          hydrate: vi.fn().mockResolvedValue(0)
+        }
+      };
+
+      vi.spyOn(mockClient, 'session').mockReturnValue(mockSession as any);
+
+      const result = await getSessionState(mockClient, 'session-new');
+      expect(result.status).toBe('busy');
+      expect(result.lastActivity).toBeUndefined();
+    });
+
+    it('codeReview should return empty files list when activities are undefined', async () => {
+       const snapshot = createMockSnapshot({
+        id: 'session-new',
+        state: 'queued',
+        title: 'New Session'
+      });
+
+      const mockSession = {
+        snapshot: vi.fn().mockResolvedValue({
+          ...snapshot,
+          activities: undefined
+        }),
+        activities: {
+          hydrate: vi.fn().mockResolvedValue(0)
+        }
+      };
+      vi.spyOn(mockClient, 'session').mockReturnValue(mockSession as any);
+
+      const result = await codeReview(mockClient, 'session-new');
+      expect(result.files).toEqual([]);
+    });
+
+    it('showDiff should return empty patch when activities are undefined and activityId is provided', async () => {
+       const snapshot = createMockSnapshot({
+        id: 'session-new',
+        state: 'queued',
+        title: 'New Session'
+      });
+
+      const mockSession = {
+        snapshot: vi.fn().mockResolvedValue({
+          ...snapshot,
+          activities: undefined
+        }),
+        activities: {
+          hydrate: vi.fn().mockResolvedValue(0)
+        }
+      };
+      vi.spyOn(mockClient, 'session').mockReturnValue(mockSession as any);
+
+      const result = await showDiff(mockClient, 'session-new', { activityId: 'non-existent' });
+      expect(result.unidiffPatch).toBe('');
+    });
+  });
+
+  describe('Session with malformed changeSet (raw property vs function)', () => {
+    it('codeReview should handle non-function changeSet gracefully', async () => {
+      const snapshot = createMockSnapshot({
+        id: 'session-stable',
+        state: 'completed',
+        title: 'Completed Session'
+      });
+
+      (snapshot as any).changeSet = { gitPatch: { unidiffPatch: '' } };
+
+      mockSessionWithSnapshot(mockClient, snapshot);
+
+      const result = await codeReview(mockClient, 'session-stable');
+      expect(result.files).toEqual([]);
+    });
+
+    it('showDiff should handle non-function changeSet gracefully', async () => {
+       const snapshot = createMockSnapshot({
+        id: 'session-stable',
+        state: 'completed',
+        title: 'Completed Session'
+      });
+
+      (snapshot as any).changeSet = { gitPatch: { unidiffPatch: '' } };
+
+      mockSessionWithSnapshot(mockClient, snapshot);
+
+      const result = await showDiff(mockClient, 'session-stable');
+      expect(result.unidiffPatch).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
Add defensive checks for `snapshot.activities` and `snapshot.changeSet` in:
- `codeReview`
- `getSessionState`
- `showDiff`

This prevents crashes when querying new sessions (where activities are undefined) or when the SDK returns a raw changeSet object.

Added regression tests in `packages/mcp/tests/functions/null-safety.test.ts`.

---
*PR created automatically by Jules for task [5264634780849863753](https://jules.google.com/task/5264634780849863753) started by @davideast*