### PR TITLE
Fix session lifecycle issues: autoPr consistency and polling timeout

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -57,6 +57,7 @@ import {
  */
 export type InternalConfig = {
   pollingIntervalMs: number;
+  pollingTimeoutMs: number;
   requestTimeoutMs: number;
 };
 
@@ -114,6 +115,7 @@ export class JulesClientImpl implements JulesClient {
     // Apply defaults to the user-provided config
     this.config = {
       pollingIntervalMs: options.config?.pollingIntervalMs ?? 5000,
+      pollingTimeoutMs: options.config?.pollingTimeoutMs ?? 3600000,
       requestTimeoutMs: options.config?.requestTimeoutMs ?? 30000,
     };
 
@@ -563,6 +565,7 @@ export class JulesClientImpl implements JulesClient {
           sessionId,
           this.apiClient,
           this.config.pollingIntervalMs,
+          this.config.pollingTimeoutMs,
         );
         // Cache the final state
         await this.storage.upsert(finalSession);
@@ -633,7 +636,10 @@ export class JulesClientImpl implements JulesClient {
           method: 'POST',
           body: {
             ...body,
-            automationMode: 'AUTOMATION_MODE_UNSPECIFIED',
+            automationMode:
+              config.autoPr === false
+                ? 'AUTOMATION_MODE_UNSPECIFIED'
+                : 'AUTO_CREATE_PR',
             requirePlanApproval: config.requireApproval ?? true,
           },
         },

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -148,3 +148,12 @@ export class InvalidStateError extends JulesError {
     super(message);
   }
 }
+
+/**
+ * Thrown when a polling operation exceeds the configured timeout.
+ */
+export class TimeoutError extends JulesError {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/packages/core/src/polling.ts
+++ b/packages/core/src/polling.ts
@@ -17,6 +17,7 @@
 // src/polling.ts
 import { ApiClient } from './api.js';
 import { SessionResource } from './types.js';
+import { TimeoutError } from './errors.js';
 
 // A helper function for delaying execution.
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -29,7 +30,9 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
  * @param apiClient The API client for making requests.
  * @param predicateFn A function that returns `true` if polling should stop.
  * @param pollingInterval The interval in milliseconds between poll attempts.
+ * @param timeoutMs The maximum duration in milliseconds to poll before throwing.
  * @returns The session resource that satisfied the predicate.
+ * @throws {TimeoutError} If the timeout is reached before the predicate is met.
  * @internal
  */
 export async function pollSession(
@@ -37,8 +40,17 @@ export async function pollSession(
   apiClient: ApiClient,
   predicateFn: (session: SessionResource) => boolean,
   pollingInterval: number,
+  timeoutMs?: number,
 ): Promise<SessionResource> {
+  const startTime = Date.now();
+
   while (true) {
+    if (timeoutMs && Date.now() - startTime > timeoutMs) {
+      throw new TimeoutError(
+        `Polling for session ${sessionId} timed out after ${timeoutMs}ms`,
+      );
+    }
+
     const session = await apiClient.request<SessionResource>(
       `sessions/${sessionId}`,
     );
@@ -57,13 +69,16 @@ export async function pollSession(
  * @param sessionId The ID of the session to poll.
  * @param apiClient The API client for making requests.
  * @param pollingInterval The interval in milliseconds between poll attempts.
+ * @param timeoutMs The maximum duration in milliseconds to poll before throwing.
  * @returns The final SessionResource.
+ * @throws {TimeoutError} If the timeout is reached before the session completes.
  * @internal
  */
 export async function pollUntilCompletion(
   sessionId: string,
   apiClient: ApiClient,
   pollingInterval: number,
+  timeoutMs?: number,
 ): Promise<SessionResource> {
   return pollSession(
     sessionId,
@@ -73,5 +88,6 @@ export async function pollUntilCompletion(
       return state === 'completed' || state === 'failed';
     },
     pollingInterval,
+    timeoutMs,
   );
 }

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -261,6 +261,7 @@ export class SessionClientImpl implements SessionClient {
       this.id,
       this.apiClient,
       this.config.pollingIntervalMs,
+      this.config.pollingTimeoutMs,
     );
     // Write-Through: Persist final state
     await this.sessionStorage.upsert(finalSession);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -96,6 +96,12 @@ export interface JulesOptions {
      */
     pollingIntervalMs?: number;
     /**
+     * The timeout in milliseconds for session polling operations.
+     * If the session does not complete within this time, a TimeoutError is thrown.
+     * @default 3600000 (1 hour)
+     */
+    pollingTimeoutMs?: number;
+    /**
      * The timeout in milliseconds for individual HTTP requests to the Jules API.
      * @default 30000
      */

--- a/packages/core/tests/polling.test.ts
+++ b/packages/core/tests/polling.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { pollSession, pollUntilCompletion } from '../src/polling.js';
 import { ApiClient } from '../src/api.js';
 import { SessionResource, SessionOutcome } from '../src/types.js';
+import { TimeoutError } from '../src/errors.js';
 
 const mockOutcome: SessionOutcome = {
   sessionId: 'test-session-id',
@@ -123,6 +124,32 @@ describe('polling helpers', () => {
 
       expect(result).toEqual(completedSession);
       expect(mockApiClient.request).toHaveBeenCalledTimes(3);
+    });
+
+    it('should throw TimeoutError if timeout is exceeded', async () => {
+      vi.useFakeTimers();
+
+      const runningSession: SessionResource = {
+        ...baseSession,
+        state: 'inProgress',
+      };
+
+      vi.mocked(mockApiClient.request).mockResolvedValue(runningSession);
+
+      const promise = pollSession(
+        sessionId,
+        mockApiClient,
+        (s) => s.state === 'completed',
+        pollingInterval,
+        200, // 200ms timeout
+      );
+
+      const assertion = expect(promise).rejects.toThrow(TimeoutError);
+
+      // Advance time beyond timeout
+      await vi.advanceTimersByTimeAsync(300);
+
+      await assertion;
     });
   });
 

--- a/packages/core/tests/session_lifecycle_fixes.test.ts
+++ b/packages/core/tests/session_lifecycle_fixes.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// tests/session_lifecycle_fixes.test.ts
+import {
+  beforeAll,
+  afterAll,
+  afterEach,
+  describe,
+  it,
+  expect,
+  vi,
+} from 'vitest';
+import { server } from './mocks/server.js';
+import { jules as defaultJules } from '../src/index.js';
+import { http, HttpResponse } from 'msw';
+import { TimeoutError } from '../src/errors.js';
+
+// Set up the mock server
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const API_KEY = 'test-api-key';
+const BASE_URL = 'https://jules.googleapis.com/v1alpha';
+const MOCK_SESSION_ID = 'lifecycle-session-123';
+
+describe('Session Lifecycle Fixes', () => {
+  const jules = defaultJules.with({
+    apiKey: API_KEY,
+    config: { pollingIntervalMs: 10 }, // Fast polling for tests
+  });
+
+  beforeAll(() => {
+    vi.useFakeTimers();
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  describe('autoPr Behavior', () => {
+    it('should send AUTO_CREATE_PR when autoPr is explicitly true', async () => {
+      let requestBody: any;
+      server.use(
+        http.post(`${BASE_URL}/sessions`, async ({ request }) => {
+          requestBody = await request.json();
+          return HttpResponse.json({
+            id: MOCK_SESSION_ID,
+            name: `sessions/${MOCK_SESSION_ID}`,
+          });
+        }),
+      );
+
+      await jules.session({
+        prompt: 'test',
+        autoPr: true,
+      });
+
+      expect(requestBody.automationMode).toBe('AUTO_CREATE_PR');
+    });
+
+    it('should send AUTOMATION_MODE_UNSPECIFIED when autoPr is explicitly false', async () => {
+      let requestBody: any;
+      server.use(
+        http.post(`${BASE_URL}/sessions`, async ({ request }) => {
+          requestBody = await request.json();
+          return HttpResponse.json({
+            id: MOCK_SESSION_ID,
+            name: `sessions/${MOCK_SESSION_ID}`,
+          });
+        }),
+      );
+
+      await jules.session({
+        prompt: 'test',
+        autoPr: false,
+      });
+
+      expect(requestBody.automationMode).toBe('AUTOMATION_MODE_UNSPECIFIED');
+    });
+
+    it('should send AUTO_CREATE_PR when autoPr is undefined (default)', async () => {
+      let requestBody: any;
+      server.use(
+        http.post(`${BASE_URL}/sessions`, async ({ request }) => {
+          requestBody = await request.json();
+          return HttpResponse.json({
+            id: MOCK_SESSION_ID,
+            name: `sessions/${MOCK_SESSION_ID}`,
+          });
+        }),
+      );
+
+      await jules.session({
+        prompt: 'test',
+      });
+
+      expect(requestBody.automationMode).toBe('AUTO_CREATE_PR');
+    });
+  });
+
+  describe('Polling Timeout', () => {
+    it('should throw TimeoutError if result() times out', async () => {
+      const julesWithShortTimeout = defaultJules.with({
+        apiKey: API_KEY,
+        config: {
+          pollingIntervalMs: 100,
+          pollingTimeoutMs: 500, // Short timeout
+        },
+      });
+
+      server.use(
+        http.post(`${BASE_URL}/sessions`, () =>
+          HttpResponse.json({
+            id: MOCK_SESSION_ID,
+            name: `sessions/${MOCK_SESSION_ID}`,
+            state: 'inProgress',
+          }),
+        ),
+        http.get(`${BASE_URL}/sessions/${MOCK_SESSION_ID}`, () =>
+          HttpResponse.json({
+            id: MOCK_SESSION_ID,
+            name: `sessions/${MOCK_SESSION_ID}`,
+            state: 'inProgress', // Always in progress
+          }),
+        ),
+      );
+
+      const session = await julesWithShortTimeout.session({
+        prompt: 'test',
+      });
+
+      const resultPromise = session.result();
+      const assertion = expect(resultPromise).rejects.toThrow(TimeoutError);
+
+      // Advance time beyond timeout
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await assertion;
+    });
+  });
+});


### PR DESCRIPTION
- Fixed `jules.session(config)` to respect `config.autoPr` and correctly set `automationMode`. It now defaults to `AUTO_CREATE_PR` unless explicitly set to `false`.
- Implemented a timeout mechanism for session polling to prevent infinite hangs.
- Added `TimeoutError` in `packages/core/src/errors.ts`.
- Added `pollingTimeoutMs` to `JulesOptions` (default: 1 hour).
- Updated `pollSession` and `pollUntilCompletion` to support timeout.
- Updated `run()` and `session.result()` to use the configured timeout.
- Added tests for timeout behavior and `autoPr` logic.

---
*PR created automatically by Jules for task [1972274119566780992](https://jules.google.com/task/1972274119566780992) started by @davideast*