### PR TITLE
fix(core): retry on 404 in sources.get() for reliability

### DIFF
--- a/packages/core/src/sources.ts
+++ b/packages/core/src/sources.ts
@@ -17,6 +17,7 @@
 // src/sources.ts
 import { ApiClient } from './api.js';
 import { JulesApiError } from './errors.js';
+import { withFirstRequestRetry } from './retry-utils.js';
 import { Source, SourceManager, GitHubRepo } from './types.js';
 
 // Internal type representing the raw source from the REST API
@@ -114,7 +115,9 @@ class SourceManagerImpl {
     const resourceName = `sources/github/${github}`;
 
     try {
-      const rawSource = await this.apiClient.request<RawSource>(resourceName);
+      const rawSource = await withFirstRequestRetry(() =>
+        this.apiClient.request<RawSource>(resourceName),
+      );
       if (!rawSource) {
         return undefined;
       }


### PR DESCRIPTION
This change improves the reliability of `sources.get()` by automatically retrying when a 404 error is encountered, which can happen due to eventual consistency or backend flakiness.

It uses the existing `withFirstRequestRetry` utility to perform retries with exponential backoff.

Test changes:
- Updated `packages/core/tests/sources.test.ts` to use fake timers for the existing 404 test case to avoid slow tests.
- Added a new test case to `packages/core/tests/sources.test.ts` to verify that retries are performed and that the function succeeds if the source eventually appears.

---
*PR created automatically by Jules for task [15164397431026414010](https://jules.google.com/task/15164397431026414010) started by @davideast*