### PR TITLE
fix(session): respect autoPr config and verify timeout logic

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -635,9 +635,9 @@ export class JulesClientImpl implements JulesClient {
           body: {
             ...body,
             automationMode:
-              config.autoPr === true
-                ? 'AUTO_CREATE_PR'
-                : 'AUTOMATION_MODE_UNSPECIFIED',
+              config.autoPr === false
+                ? 'AUTOMATION_MODE_UNSPECIFIED'
+                : 'AUTO_CREATE_PR',
             requirePlanApproval: config.requireApproval ?? true,
           },
         },

--- a/packages/core/tests/session.test.ts
+++ b/packages/core/tests/session.test.ts
@@ -165,6 +165,38 @@ describe('jules.session()', () => {
     expect(session.id).toBe('SESSION_123');
     expect(capturedRequestBody).toBeDefined();
     expect(capturedRequestBody.requirePlanApproval).toBe(true);
+    // Should default to AUTO_CREATE_PR as per issue #18
+    expect(capturedRequestBody.automationMode).toBe('AUTO_CREATE_PR');
+  });
+
+  it('should respect autoPr: false', async () => {
+    await jules.session({
+      prompt: 'Refactor.',
+      source: { github: 'bobalover/boba-auth', baseBranch: 'main' },
+      autoPr: false,
+    });
+    expect(capturedRequestBody.automationMode).toBe(
+      'AUTOMATION_MODE_UNSPECIFIED',
+    );
+  });
+
+  it('should respect autoPr: true', async () => {
+    await jules.session({
+      prompt: 'Refactor.',
+      source: { github: 'bobalover/boba-auth', baseBranch: 'main' },
+      autoPr: true,
+    });
+    expect(capturedRequestBody.automationMode).toBe('AUTO_CREATE_PR');
+  });
+
+  it('should allow requireApproval: false with correct automationMode', async () => {
+    await jules.session({
+      prompt: 'Refactor.',
+      source: { github: 'bobalover/boba-auth', baseBranch: 'main' },
+      requireApproval: false,
+    });
+    expect(capturedRequestBody.requirePlanApproval).toBe(false);
+    expect(capturedRequestBody.automationMode).toBe('AUTO_CREATE_PR');
   });
 
   it('should rehydrate a session from an ID without an API call', () => {


### PR DESCRIPTION
This PR addresses issues #18, #23, and #24.

1.  **Session Configuration (#18, #24):** Updated `jules.session()` in `packages/core/src/client.ts` to explicitly set `automationMode` to `AUTO_CREATE_PR` unless `autoPr` is explicitly set to `false`. This allows `requireApproval: false` to work correctly without triggering a `FAILED_PRECONDITION` error from the backend. Added comprehensive tests in `packages/core/tests/session.test.ts` to verify this behavior.

2.  **Polling Hangs (#23):** Verified that the timeout mechanism (`TimeoutError` in `errors.ts`, `timeoutMs` in `polling.ts`, and its usage in `client.ts` and `session.ts`) is already implemented and functioning correctly. Verified existing tests in `packages/core/tests/polling.test.ts` and `packages/core/tests/session.test.ts` pass, confirming the fix for #23 is present.

---
*PR created automatically by Jules for task [5385305803347607065](https://jules.google.com/task/5385305803347607065) started by @davideast*