### PR TITLE
Fix jules.session to respect autoPr config

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -633,7 +633,10 @@ export class JulesClientImpl implements JulesClient {
           method: 'POST',
           body: {
             ...body,
-            automationMode: 'AUTOMATION_MODE_UNSPECIFIED',
+            automationMode:
+              config.autoPr === false
+                ? 'AUTOMATION_MODE_UNSPECIFIED'
+                : 'AUTO_CREATE_PR',
             requirePlanApproval: config.requireApproval ?? true,
           },
         },

--- a/packages/core/tests/session.test.ts
+++ b/packages/core/tests/session.test.ts
@@ -166,6 +166,34 @@ describe('jules.session()', () => {
     expect(capturedRequestBody.requirePlanApproval).toBe(true);
   });
 
+  it('should send AUTO_CREATE_PR when autoPr is true', async () => {
+    await jules.session({
+      prompt: 'test',
+      source: { github: 'bobalover/boba-auth', baseBranch: 'main' },
+      autoPr: true,
+    });
+    expect(capturedRequestBody.automationMode).toBe('AUTO_CREATE_PR');
+  });
+
+  it('should send AUTOMATION_MODE_UNSPECIFIED when autoPr is false', async () => {
+    await jules.session({
+      prompt: 'test',
+      source: { github: 'bobalover/boba-auth', baseBranch: 'main' },
+      autoPr: false,
+    });
+    expect(capturedRequestBody.automationMode).toBe(
+      'AUTOMATION_MODE_UNSPECIFIED',
+    );
+  });
+
+  it('should send AUTO_CREATE_PR when autoPr is undefined (default)', async () => {
+    await jules.session({
+      prompt: 'test',
+      source: { github: 'bobalover/boba-auth', baseBranch: 'main' },
+    });
+    expect(capturedRequestBody.automationMode).toBe('AUTO_CREATE_PR');
+  });
+
   it('should rehydrate a session from an ID without an API call', () => {
     const spy = vi.spyOn(global, 'fetch');
     const session = jules.session('EXISTING_SESSION');


### PR DESCRIPTION
Updated `packages/core/src/client.ts` to correctly map `config.autoPr` to `automationMode`.
- If `autoPr` is `false`, it sends `AUTOMATION_MODE_UNSPECIFIED`.
- If `autoPr` is `true` or `undefined`, it sends `AUTO_CREATE_PR`.
This aligns `session()` behavior with `run()` and allows for automated sessions via `session()`.
Added tests in `packages/core/tests/session.test.ts` to verify the behavior for all cases.

---
*PR created automatically by Jules for task [4609020124300937952](https://jules.google.com/task/4609020124300937952) started by @davideast*