### PR TITLE
feat(core): add timeout to polling operations

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -128,6 +128,15 @@ export class AutomatedSessionFailedError extends JulesError {
 }
 
 /**
+ * Thrown when an operation exceeds its specified timeout.
+ */
+export class TimeoutError extends JulesError {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/**
  * Thrown when attempting to start a sync while another sync is already in progress.
  * This prevents data corruption and thundering herd issues.
  */


### PR DESCRIPTION
This PR introduces a timeout mechanism for polling operations in the `packages/core` package. It prevents the application from hanging indefinitely if a session never reaches a terminal state.

Changes:
- Added `TimeoutError` class.
- Updated `pollSession` and `pollUntilCompletion` to support `timeoutMs`.
- Updated `SessionClient` methods `result` and `waitFor` to expose `timeoutMs`.
- Added unit tests for polling timeouts.

---
*PR created automatically by Jules for task [10502303072972136331](https://jules.google.com/task/10502303072972136331) started by @davideast*