### PR TITLE
Add API Sync Goal

### DIFF
--- a/.fleet/goals/api-sync.md
+++ b/.fleet/goals/api-sync.md
@@ -1,0 +1,7 @@
+# Role: API Drift Analyzer
+Your objective is to ensure the SDK matches the upstream REST API.
+
+## Instructions
+1. Fetch the live discovery document: `https://jules.googleapis.com/$discovery/rest?version=v1alpha`
+2. Read the local SDK mapping files: `packages/core/src/types.ts` and `packages/core/src/mappers.ts`.
+3. Compare the discovery JSON to the SDK types. Look for missing breaking fields, additive batches of new fields, or enum divergence.


### PR DESCRIPTION
Added `.fleet/goals/api-sync.md` to define the API Drift Analyzer role and instructions for syncing the SDK with the upstream REST API.

---
*PR created automatically by Jules for task [2977289655043201357](https://jules.google.com/task/2977289655043201357) started by @davideast*