### PR TITLE
Update SDK types for Jules API v1alpha compatibility

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -210,6 +210,8 @@ export interface GitHubRepo {
   owner: string;
   repo: string;
   isPrivate: boolean;
+  defaultBranch?: string;
+  branches?: string[];
 }
 
 /**
@@ -312,6 +314,8 @@ export interface SourceContext {
   githubRepoContext?: {
     startingBranch: string;
   };
+  workingBranch?: string;
+  environmentVariablesEnabled?: boolean;
 }
 
 /**
@@ -329,7 +333,7 @@ export interface SessionResource {
   id: string;
   prompt: string;
   sourceContext: SourceContext;
-  source: Source;
+  source?: Source;
   title: string;
   /**
    * The time the session was created (RFC 3339 timestamp).
@@ -361,6 +365,7 @@ export interface SessionResource {
    * The generated files of the session if it reaches a stable state.
    */
   generatedFiles?: GeneratedFile[];
+  archived: boolean;
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/core/tests/api_schema_compatibility.test.ts
+++ b/packages/core/tests/api_schema_compatibility.test.ts
@@ -1,0 +1,61 @@
+
+import { describe, it, expect } from 'vitest';
+import {
+  SessionResource,
+  SourceContext,
+  SessionOutcome,
+  SessionState,
+  GeneratedFile,
+  Source,
+} from '../src/types.js';
+
+describe('API Schema Compatibility', () => {
+  it('should allow SessionResource to be defined without "source" and with "archived" (optional)', () => {
+    // This is primarily a compile-time test, but we can also verify runtime structure.
+    const validSession: SessionResource = {
+      name: 'sessions/123',
+      id: '123',
+      prompt: 'fix bug',
+      sourceContext: {
+        source: 'sources/github/owner/repo',
+        // Verify these new fields exist on the type (if strict compilation)
+        workingBranch: 'feature-branch',
+        environmentVariablesEnabled: true,
+      },
+      // 'source' is omitted here.
+      title: 'My Session',
+      createTime: '2023-01-01T00:00:00Z',
+      updateTime: '2023-01-01T00:00:00Z',
+      state: 'completed' as SessionState,
+      url: 'http://jules.google.com/sessions/123',
+      outputs: [],
+      outcome: {} as SessionOutcome,
+      // Verify this new field exists on the type
+      archived: false,
+    };
+
+    expect(validSession.id).toBe('123');
+    expect(validSession.source).toBeUndefined();
+    expect(validSession.archived).toBe(false);
+    expect(validSession.sourceContext.workingBranch).toBe('feature-branch');
+  });
+
+  it('should allow SourceContext and GitHubRepo to have new fields', () => {
+    const validSource: Source = {
+      type: 'githubRepo',
+      name: 'sources/github/owner/repo',
+      id: 'github/owner/repo',
+      githubRepo: {
+        owner: 'owner',
+        repo: 'repo',
+        isPrivate: false,
+        // New fields:
+        defaultBranch: 'main',
+        branches: ['main', 'dev'],
+      },
+    };
+
+    expect(validSource.githubRepo.defaultBranch).toBe('main');
+    expect(validSource.githubRepo.branches).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Updated `packages/core/src/types.ts` to reflect the latest Jules API v1alpha schema. Specifically, the `SessionResource` now has an optional `source` field and a required `archived` field. The `SourceContext` and `GitHubRepo` interfaces have also been expanded with new fields. A new test file `packages/core/tests/api_schema_compatibility.test.ts` has been added to verify these type definitions.

Fixes #59.

---
*PR created automatically by Jules for task [3858864629217239437](https://jules.google.com/task/3858864629217239437) started by @davideast*