### PR TITLE
Update SessionResource with automation fields

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -261,6 +261,11 @@ export type SessionState =
   | 'completed';
 
 /**
+ * The automation mode for the session.
+ */
+export type AutomationMode = 'AUTOMATION_MODE_UNSPECIFIED' | 'AUTO_CREATE_PR';
+
+/**
  * The entity that an activity originates from.
  */
 export type Origin = 'user' | 'agent' | 'system';
@@ -335,6 +340,9 @@ export interface SessionResource {
   sourceContext: SourceContext;
   source?: Source;
   title: string;
+  requirePlanApproval?: boolean;
+  automationMode?: AutomationMode;
+  archived?: boolean;
   /**
    * The time the session was created (RFC 3339 timestamp).
    */
@@ -365,7 +373,6 @@ export interface SessionResource {
    * The generated files of the session if it reaches a stable state.
    */
   generatedFiles?: GeneratedFile[];
-  archived: boolean;
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Updates `SessionResource` and `SessionConfig` mapping to include missing fields required for correct session automation and approval workflows. This ensures the SDK correctly reflects the API capabilities for controlling agent autonomy.

Changes:
- `packages/core/src/types.ts`: Added `AutomationMode`, `requirePlanApproval`, `automationMode`, and `archived` to `SessionResource`.
- `packages/core/tests/automated_session.test.ts`: Added tests for new fields.


---
*PR created automatically by Jules for task [16938268178475411982](https://jules.google.com/task/16938268178475411982) started by @davideast*