### PR TITLE
Update PullRequest interface with baseRef and headRef

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -273,6 +273,8 @@ export interface PullRequest {
   url: string;
   title: string;
   description: string;
+  baseRef?: string;
+  headRef?: string;
 }
 
 /**

--- a/packages/core/tests/pull_request_schema.test.ts
+++ b/packages/core/tests/pull_request_schema.test.ts
@@ -1,0 +1,29 @@
+
+import { describe, it, expect } from 'vitest';
+import { PullRequest } from '../src/types.js';
+
+describe('Pull Request Schema', () => {
+  it('should support baseRef and headRef fields when provided', () => {
+    const pr: PullRequest = {
+      url: 'http://github.com/owner/repo/pull/1',
+      title: 'Fix bug',
+      description: 'Fixes the bug',
+      baseRef: 'main',
+      headRef: 'feature-branch',
+    };
+
+    expect(pr.baseRef).toBe('main');
+    expect(pr.headRef).toBe('feature-branch');
+  });
+
+  it('should handle missing baseRef and headRef gracefully', () => {
+    const pr: PullRequest = {
+      url: 'http://github.com/owner/repo/pull/1',
+      title: 'Fix bug',
+      description: 'Fixes the bug',
+    };
+
+    expect(pr.baseRef).toBeUndefined();
+    expect(pr.headRef).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Adds optional `baseRef` and `headRef` fields to the `PullRequest` interface in `packages/core/src/types.ts`.
This aligns the SDK types with the v1alpha API response, enabling access to these fields in automated workflows.
Includes a new test file `packages/core/tests/pull_request_schema.test.ts` to verify the schema update.

Fixes #64

---
*PR created automatically by Jules for task [763041496816742972](https://jules.google.com/task/763041496816742972) started by @davideast*