### PR TITLE
feat(core): add session archival and filtering

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -344,6 +344,46 @@ export class SessionClientImpl implements SessionClient {
   }
 
   /**
+   * Archives the session, hiding it from default lists and marking it as inactive.
+   *
+   * **Side Effects:**
+   * - Sends a POST request to `sessions/{id}:archive`.
+   * - Updates the local cache to reflect the archived status.
+   */
+  async archive(): Promise<void> {
+    await this.request(`sessions/${this.id}:archive`, {
+      method: 'POST',
+      body: {},
+    });
+    // Write-Through: Update local cache if present
+    const cached = await this.sessionStorage.get(this.id);
+    if (cached) {
+      cached.resource.archived = true;
+      await this.sessionStorage.upsert(cached.resource);
+    }
+  }
+
+  /**
+   * Unarchives the session, restoring it to the active list.
+   *
+   * **Side Effects:**
+   * - Sends a POST request to `sessions/{id}:unarchive`.
+   * - Updates the local cache to reflect the unarchived status.
+   */
+  async unarchive(): Promise<void> {
+    await this.request(`sessions/${this.id}:unarchive`, {
+      method: 'POST',
+      body: {},
+    });
+    // Write-Through: Update local cache if present
+    const cached = await this.sessionStorage.get(this.id);
+    if (cached) {
+      cached.resource.archived = false;
+      await this.sessionStorage.upsert(cached.resource);
+    }
+  }
+
+  /**
    * Creates a point-in-time snapshot of the session.
    * This is a network operation that fetches the latest session info and all activities.
    *

--- a/packages/core/src/sessions.ts
+++ b/packages/core/src/sessions.ts
@@ -32,6 +32,14 @@ export type ListSessionsOptions = {
    * Set to `false` to disable side effects.
    */
   persist?: boolean;
+  /**
+   * Filter string to apply to the list request.
+   * Follows the Google API filtering syntax.
+   *
+   * @example
+   * 'archived = true'
+   */
+  filter?: string;
 };
 
 export type ListSessionsResponse = {
@@ -130,6 +138,7 @@ export class SessionCursor
     if (this.options.pageSize)
       params.pageSize = this.options.pageSize.toString();
     if (pageToken) params.pageToken = pageToken;
+    if (this.options.filter) params.filter = this.options.filter;
 
     // Use the existing ApiClient from your SDK
     const response = await this.apiClient.request<{

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1112,6 +1112,22 @@ export interface SessionClient {
   info(): Promise<SessionResource>;
 
   /**
+   * Archives the session, hiding it from default lists and marking it as inactive.
+   *
+   * @example
+   * await session.archive();
+   */
+  archive(): Promise<void>;
+
+  /**
+   * Unarchives the session, restoring it to the active list.
+   *
+   * @example
+   * await session.unarchive();
+   */
+  unarchive(): Promise<void>;
+
+  /**
    * Creates a point-in-time snapshot of the session with all activities loaded and derived analytics computed.
    * This is a network operation with cache heuristics.
    *

--- a/packages/core/tests/session.test.ts
+++ b/packages/core/tests/session.test.ts
@@ -124,6 +124,18 @@ const server = setupServer(
       outputs: [],
     });
   }),
+  http.post(
+    'https://jules.googleapis.com/v1alpha/sessions/SESSION_123:archive',
+    () => {
+      return HttpResponse.json({});
+    },
+  ),
+  http.post(
+    'https://jules.googleapis.com/v1alpha/sessions/SESSION_123:unarchive',
+    () => {
+      return HttpResponse.json({});
+    },
+  ),
 );
 
 beforeAll(() => {
@@ -284,6 +296,40 @@ describe('SessionClient', () => {
       await expect(invalidStateSession.approve()).rejects.toThrow();
       // API was called (no pre-check)
       expect(approvePlanCalled).toBe(true);
+    });
+  });
+
+  describe('archive()', () => {
+    it('should make the archive API call', async () => {
+      let called = false;
+      server.use(
+        http.post(
+          'https://jules.googleapis.com/v1alpha/sessions/SESSION_123:archive',
+          async () => {
+            called = true;
+            return HttpResponse.json({});
+          },
+        ),
+      );
+      await session.archive();
+      expect(called).toBe(true);
+    });
+  });
+
+  describe('unarchive()', () => {
+    it('should make the unarchive API call', async () => {
+      let called = false;
+      server.use(
+        http.post(
+          'https://jules.googleapis.com/v1alpha/sessions/SESSION_123:unarchive',
+          async () => {
+            called = true;
+            return HttpResponse.json({});
+          },
+        ),
+      );
+      await session.unarchive();
+      expect(called).toBe(true);
     });
   });
 

--- a/packages/core/tests/sessions.test.ts
+++ b/packages/core/tests/sessions.test.ts
@@ -231,4 +231,17 @@ describe('jules.sessions()', () => {
     expect(mockStorageFactory.session).toHaveBeenCalled();
     expect(mockSessionStorage.upsertMany).toHaveBeenCalledWith(mockSessions);
   });
+
+  // NEW: Test for filtering
+  it('should include filter query parameter when provided', async () => {
+    const mockSessions = [createSession('1')];
+    (apiClient.request as any).mockResolvedValue({ sessions: mockSessions });
+
+    const filter = 'archived = true';
+    await client.sessions({ filter });
+
+    expect(apiClient.request).toHaveBeenCalledWith('sessions', {
+      query: { filter },
+    });
+  });
 });


### PR DESCRIPTION
This PR adds support for session archival and filtering in the Jules SDK.

**Changes:**
- `packages/core/src/types.ts`: Added `archive()` and `unarchive()` to `SessionClient`.
- `packages/core/src/session.ts`: Implemented `archive()` and `unarchive()` methods in `SessionClientImpl`. These methods send POST requests to the respective endpoints and update the local session storage.
- `packages/core/src/sessions.ts`: Added `filter` to `ListSessionsOptions` and updated `SessionCursor.fetchPage` to include the filter in the query parameters.
- `packages/core/tests/session.test.ts`: Added tests for `archive()` and `unarchive()`.
- `packages/core/tests/sessions.test.ts`: Added tests for session filtering.

These changes align the SDK with the v1alpha API capabilities.

---
*PR created automatically by Jules for task [14631891832099132522](https://jules.google.com/task/14631891832099132522) started by @davideast*