### PR TITLE
[Fleet Execution] API Schema Expansion: Activity Description

### DIFF
--- a/packages/core/src/mappers.ts
+++ b/packages/core/src/mappers.ts
@@ -85,6 +85,7 @@ export function mapRestActivityToSdkActivity(
     createTime,
     originator,
     artifacts: rawArtifacts,
+    description,
   } = restActivity;
 
   const activityId = name.split('/').pop();
@@ -97,6 +98,7 @@ export function mapRestActivityToSdkActivity(
   const baseActivity = {
     name,
     id: activityId,
+    description,
     createTime,
     originator: originator || 'system',
     artifacts,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -652,6 +652,10 @@ interface BaseActivity {
   name: string;
   id: string;
   /**
+   * A generic, human-readable description for the activity.
+   */
+  description?: string;
+  /**
    * The time at which this activity was created (RFC 3339 timestamp).
    */
   createTime: string;

--- a/packages/core/tests/mappers.test.ts
+++ b/packages/core/tests/mappers.test.ts
@@ -98,6 +98,19 @@ describe('mapRestActivityToSdkActivity', () => {
     expect((sdkActivity as any).message).toBe('Hello there!');
   });
 
+  it('should map a description field correctly', () => {
+    const restActivity = {
+      ...BASE_REST_ACTIVITY,
+      description: 'An agent description',
+      agentMessaged: { agentMessage: 'Hello there!' },
+    };
+    const sdkActivity = mapRestActivityToSdkActivity(
+      restActivity,
+      mockPlatform,
+    );
+    expect((sdkActivity as any).description).toBe('An agent description');
+  });
+
   it('should map a progressUpdated activity correctly', () => {
     const restActivity = {
       ...BASE_REST_ACTIVITY,


### PR DESCRIPTION
Updates `BaseActivity` interface to include optional `description` field and modifies `mapRestActivityToSdkActivity` to extract it from the API response. Includes unit tests to verify the mapping logic and JSDoc for the new field.

---
*PR created automatically by Jules for task [9592284028335186803](https://jules.google.com/task/9592284028335186803) started by @davideast*