### PR TITLE
Fix RestGitHubRepo type and mapRestSourceToSdkSource logic

### DIFF
--- a/packages/core/src/mappers.ts
+++ b/packages/core/src/mappers.ts
@@ -191,11 +191,16 @@ export function mapRestStateToSdkState(state: string): SessionState {
 
 export function mapRestSourceToSdkSource(rest: RestSource): Source {
   if (rest.githubRepo) {
+    const { defaultBranch, branches, ...other } = rest.githubRepo;
     return {
       type: 'githubRepo',
       name: rest.name,
       id: rest.id,
-      githubRepo: rest.githubRepo,
+      githubRepo: {
+        ...other,
+        defaultBranch: defaultBranch?.displayName,
+        branches: branches?.map((b) => b.displayName),
+      },
     };
   }
   throw new Error(`Unknown source type: ${JSON.stringify(rest)}`);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -209,8 +209,8 @@ export interface RestGitHubRepo {
   owner: string;
   repo: string;
   isPrivate: boolean;
-  defaultBranch?: string;
-  branches?: string[];
+  defaultBranch?: { displayName: string };
+  branches?: { displayName: string }[];
 }
 
 /**

--- a/packages/core/tests/mappers.test.ts
+++ b/packages/core/tests/mappers.test.ts
@@ -219,7 +219,7 @@ describe('mapRestSourceToSdkSource', () => {
         owner: 'owner',
         repo: 'repo',
         isPrivate: false,
-        defaultBranch: 'main',
+        defaultBranch: { displayName: 'main' },
       },
     };
     const sdk = mapRestSourceToSdkSource(rest);
@@ -227,6 +227,26 @@ describe('mapRestSourceToSdkSource', () => {
     if (sdk.type === 'githubRepo') {
       expect(sdk.githubRepo.owner).toBe('owner');
       expect(sdk.githubRepo.defaultBranch).toBe('main');
+    }
+  });
+
+  it('should map nested defaultBranch correctly', () => {
+    const rest: RestSource = {
+      name: 'sources/github/owner/repo',
+      id: 'github/owner/repo',
+      githubRepo: {
+        owner: 'owner',
+        repo: 'repo',
+        isPrivate: false,
+        defaultBranch: { displayName: 'main' },
+        branches: [{ displayName: 'main' }, { displayName: 'dev' }],
+      },
+    };
+    const sdk = mapRestSourceToSdkSource(rest);
+    expect(sdk.type).toBe('githubRepo');
+    if (sdk.type === 'githubRepo') {
+      expect(sdk.githubRepo.defaultBranch).toBe('main');
+      expect(sdk.githubRepo.branches).toEqual(['main', 'dev']);
     }
   });
 });


### PR DESCRIPTION
This PR aligns the `RestGitHubRepo` type definition and `mapRestSourceToSdkSource` mapper with the actual v1alpha API response structure. The API returns `defaultBranch` and `branches` as objects containing a `displayName`, whereas the previous implementation expected strings.

Changes:
- `packages/core/src/types.ts`: Updated `RestGitHubRepo` interface.
- `packages/core/src/mappers.ts`: Updated mapping logic to flatten the nested objects.
- `packages/core/tests/mappers.test.ts`: Updated tests to verify the fix and match the new type definition.


---
*PR created automatically by Jules for task [9069595848122238453](https://jules.google.com/task/9069595848122238453) started by @davideast*