### PR TITLE
Align session configuration with v1alpha API

### DIFF
--- a/packages/core/src/mappers.ts
+++ b/packages/core/src/mappers.ts
@@ -26,6 +26,7 @@ import { AutomatedSessionFailedError } from './errors.js';
 import {
   Activity,
   Artifact,
+  AutomationMode,
   ChangeSet,
   SessionOutcome,
   PullRequest,
@@ -232,6 +233,8 @@ export function mapRestSessionToSdkSession(
     ...rest,
     archived: rest.archived ?? false,
     state: mapRestStateToSdkState(rest.state),
+    requirePlanApproval: rest.requirePlanApproval,
+    automationMode: rest.automationMode as AutomationMode,
     outputs: (rest.outputs || []).map(mapRestOutputToSdkOutput),
     source: rest.source ? mapRestSourceToSdkSource(rest.source) : undefined,
     generatedFiles: rest.generatedFiles,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -283,6 +283,8 @@ export interface RestSessionOutput {
   changeSet?: ChangeSet;
 }
 
+export type AutomationMode = 'AUTOMATION_MODE_UNSPECIFIED' | 'AUTO_CREATE_PR';
+
 /**
  * Raw REST API representation of a Session Resource.
  */
@@ -296,6 +298,8 @@ export interface RestSessionResource {
   createTime: string;
   updateTime: string;
   state: string; // SCREAMING_SNAKE_CASE
+  requirePlanApproval?: boolean;
+  automationMode?: string;
   url: string;
   outputs?: RestSessionOutput[];
   activities?: any[];
@@ -396,6 +400,8 @@ export interface SessionResource {
   sourceContext: SourceContext;
   source?: Source;
   title: string;
+  requirePlanApproval?: boolean;
+  automationMode?: AutomationMode;
   /**
    * The time the session was created (RFC 3339 timestamp).
    */

--- a/packages/core/tests/mappers.test.ts
+++ b/packages/core/tests/mappers.test.ts
@@ -321,4 +321,24 @@ describe('mapRestSessionToSdkSession', () => {
     expect(sdk.outputs).toHaveLength(1);
     expect(sdk.outputs[0].type).toBe('pullRequest');
   });
+
+  it('should map session configuration fields', () => {
+    const rest: RestSessionResource = {
+      name: 'sessions/123',
+      id: '123',
+      prompt: 'prompt',
+      title: 'title',
+      createTime: '2023-01-01',
+      updateTime: '2023-01-01',
+      state: 'IN_PROGRESS',
+      url: 'url',
+      outputs: [],
+      sourceContext: { source: 's' },
+      requirePlanApproval: true,
+      automationMode: 'AUTO_CREATE_PR',
+    };
+    const sdk = mapRestSessionToSdkSession(rest, mockPlatform);
+    expect(sdk.requirePlanApproval).toBe(true);
+    expect(sdk.automationMode).toBe('AUTO_CREATE_PR');
+  });
 });


### PR DESCRIPTION
Added support for `requirePlanApproval` and `automationMode` fields in `SessionResource` and `RestSessionResource`. Updated `mapRestSessionToSdkSession` to correctly map these fields from the API response.

Fixes #87

---
*PR created automatically by Jules for task [838087888790787381](https://jules.google.com/task/838087888790787381) started by @davideast*