### PR TITLE
feat(core): implement source filtering in SourceManager

### DIFF
--- a/packages/core/src/sources.ts
+++ b/packages/core/src/sources.ts
@@ -17,7 +17,12 @@
 // src/sources.ts
 import { ApiClient } from './api.js';
 import { JulesApiError } from './errors.js';
-import { Source, SourceManager, GitHubRepo } from './types.js';
+import {
+  Source,
+  SourceManager,
+  GitHubRepo,
+  ListSourcesOptions,
+} from './types.js';
 
 // Internal type representing the raw source from the REST API
 interface RestGitHubRepo {
@@ -82,11 +87,16 @@ class SourceManagerImpl {
    * - Automatically handles API pagination by following `nextPageToken`.
    * - Yields sources one by one as they are retrieved.
    */
-  async *list(): AsyncIterable<Source> {
+  async *list(options: ListSourcesOptions = {}): AsyncIterable<Source> {
     let pageToken: string | undefined = undefined;
 
     while (true) {
-      const params: Record<string, string> = { pageSize: '100' };
+      const params: Record<string, string> = {
+        pageSize: (options.pageSize || 100).toString(),
+      };
+      if (options.filter) {
+        params.filter = options.filter;
+      }
       if (pageToken) {
         params.pageToken = pageToken;
       }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1307,6 +1307,22 @@ export interface SerializedSnapshot {
 // -----------------------------------------------------------------------------
 
 /**
+ * Options for listing sources.
+ */
+export interface ListSourcesOptions {
+  /**
+   * A filter expression to filter sources.
+   * Currently supports filtering by name (e.g., 'name="sources/github/owner/repo"').
+   */
+  filter?: string;
+  /**
+   * The maximum number of sources to return per page.
+   * @default 100
+   */
+  pageSize?: number;
+}
+
+/**
  * Interface for managing and locating connected sources.
  * Accessed via `jules.sources`.
  */
@@ -1315,14 +1331,15 @@ export interface SourceManager {
    * Iterates over all connected sources.
    * Uses an Async Iterator to abstract API pagination.
    *
+   * @param options Optional configuration for listing sources (filter, pageSize).
    * @example
-   * for await (const source of jules.sources()) {
+   * for await (const source of jules.sources({ filter: 'name="sources/github/owner/repo"' })) {
    *   if (source.type === 'githubRepo') {
    *     console.log(`Found repo: ${source.githubRepo.owner}/${source.githubRepo.repo}`);
    *   }
    * }
    */
-  (): AsyncIterable<Source>;
+  (options?: ListSourcesOptions): AsyncIterable<Source>;
 
   /**
    * Locates a specific source based on ergonomic filters.


### PR DESCRIPTION
Fixes #90

This PR updates the `SourceManager` in `@google/jules-sdk` to support server-side filtering and custom page sizes when listing sources. This aligns the SDK with the v1alpha API capabilities.

Changes:
- Modified `packages/core/src/types.ts` to define `ListSourcesOptions` and update `SourceManager` call signature.
- Modified `packages/core/src/sources.ts` to implement the filtering logic in `SourceManagerImpl.list`.
- Updated `packages/core/tests/sources.test.ts` with new test cases for filtering and pagination.

---
*PR created automatically by Jules for task [13863415910140211699](https://jules.google.com/task/13863415910140211699) started by @davideast*