### PR TITLE
fix: add --admin flag to fleet-merge

### DIFF
--- a/.github/workflows/fleet-merge.yml
+++ b/.github/workflows/fleet-merge.yml
@@ -186,7 +186,7 @@ jobs:
               else
                 # Squash merge
                 echo "  ✅ CI passed. Merging PR #${PR_NUM}..."
-                if gh pr merge "$PR_NUM" --squash; then
+                if gh pr merge "$PR_NUM" --squash --admin; then
                   echo "  🎉 PR #${PR_NUM} merged successfully."
                 else
                   echo "  ❌ Failed to merge PR #${PR_NUM}. Stopping sequential merge."


### PR DESCRIPTION
Bypasses branch protection during fleet sequential merge (requires admin rights on the repo).