### PR TITLE
feat(fleet): add auth detection TSC slice for init command

### DIFF
--- a/packages/fleet/src/__tests__/auth-detect-handler.test.ts
+++ b/packages/fleet/src/__tests__/auth-detect-handler.test.ts
@@ -1,0 +1,261 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AuthDetectHandler } from '../init/auth-detect/handler.js';
+
+// Mock octokit
+vi.mock('octokit', () => ({
+  Octokit: vi.fn().mockImplementation(() => ({
+    rest: {
+      repos: {
+        get: vi.fn().mockResolvedValue({
+          data: { full_name: 'owner/repo' },
+        }),
+      },
+      users: {
+        getAuthenticated: vi.fn().mockResolvedValue({
+          data: { login: 'testuser' },
+        }),
+      },
+    },
+  })),
+}));
+
+// Mock child_process for gh CLI
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+// Mock app auth (not used in token tests but needed for import)
+vi.mock('@octokit/auth-app', () => ({
+  createAppAuth: vi.fn(),
+}));
+
+// Mock resolvePrivateKey to avoid real key parsing in tests
+vi.mock('../../shared/auth/resolve-key.js', () => ({
+  resolvePrivateKey: vi.fn().mockReturnValue('mock-pem-key'),
+}));
+
+describe('AuthDetectHandler', () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Clean env before each test
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_APP_ID;
+    delete process.env.GITHUB_APP_PRIVATE_KEY;
+    delete process.env.GITHUB_APP_PRIVATE_KEY_BASE64;
+    delete process.env.GITHUB_APP_INSTALLATION_ID;
+    delete process.env.FLEET_APP_ID;
+    delete process.env.FLEET_APP_PRIVATE_KEY;
+    delete process.env.FLEET_APP_PRIVATE_KEY_BASE64;
+    delete process.env.FLEET_APP_INSTALLATION_ID;
+  });
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+    vi.clearAllMocks();
+  });
+
+  describe('env var detection', () => {
+    it('detects GITHUB_TOKEN from env', async () => {
+      process.env.GITHUB_TOKEN = 'ghp_test123';
+      const handler = new AuthDetectHandler();
+      const result = await handler.execute({ owner: 'owner', repo: 'repo' });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.method).toBe('token');
+        expect(result.data.source).toBe('env');
+        expect(result.data.identity).toBe('testuser');
+      }
+    });
+
+    it('detects FLEET_APP_* from env', async () => {
+      process.env.FLEET_APP_ID = '12345';
+      process.env.FLEET_APP_PRIVATE_KEY = 'base64key';
+      process.env.FLEET_APP_INSTALLATION_ID = '67890';
+      const handler = new AuthDetectHandler();
+      const result = await handler.execute({ owner: 'owner', repo: 'repo' });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.method).toBe('app');
+        expect(result.data.source).toBe('env');
+      }
+    });
+  });
+
+  describe('--auth flag gating', () => {
+    it('--auth=app ignores GITHUB_TOKEN', async () => {
+      process.env.GITHUB_TOKEN = 'ghp_test123';
+      // No app credentials set
+      const handler = new AuthDetectHandler();
+      const result = await handler.execute({
+        owner: 'owner',
+        repo: 'repo',
+        preferredMethod: 'app',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe('NO_CREDENTIALS_FOUND');
+        expect(result.error.message).toContain('app auth');
+      }
+    });
+
+    it('--auth=token ignores FLEET_APP_* vars', async () => {
+      process.env.FLEET_APP_ID = '12345';
+      process.env.FLEET_APP_PRIVATE_KEY = 'base64key';
+      process.env.FLEET_APP_INSTALLATION_ID = '67890';
+      // No GITHUB_TOKEN set, but gh CLI not available either
+      const { execSync } = await import('node:child_process');
+      vi.mocked(execSync).mockImplementation(() => { throw new Error('gh not found'); });
+
+      const handler = new AuthDetectHandler();
+      const result = await handler.execute({
+        owner: 'owner',
+        repo: 'repo',
+        preferredMethod: 'token',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe('NO_CREDENTIALS_FOUND');
+      }
+    });
+  });
+
+  describe('gh CLI fallback', () => {
+    it('falls back to gh auth token when no GITHUB_TOKEN in env', async () => {
+      const { execSync } = await import('node:child_process');
+      vi.mocked(execSync).mockReturnValue('ghp_from_gh_cli\n');
+
+      const handler = new AuthDetectHandler();
+      const result = await handler.execute({ owner: 'owner', repo: 'repo' });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.method).toBe('token');
+        expect(result.data.source).toBe('gh-cli');
+      }
+    });
+
+    it('skips gh CLI silently when gh is not installed', async () => {
+      const { execSync } = await import('node:child_process');
+      vi.mocked(execSync).mockImplementation(() => { throw new Error('command not found'); });
+
+      const handler = new AuthDetectHandler();
+      const result = await handler.execute({ owner: 'owner', repo: 'repo' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe('NO_CREDENTIALS_FOUND');
+      }
+    });
+  });
+
+  describe('alternatives for wizard', () => {
+    it('returns alternatives when both token and app are detected without preference', async () => {
+      process.env.GITHUB_TOKEN = 'ghp_test123';
+      process.env.FLEET_APP_ID = '12345';
+      process.env.FLEET_APP_PRIVATE_KEY = 'base64key';
+      process.env.FLEET_APP_INSTALLATION_ID = '67890';
+
+      const handler = new AuthDetectHandler();
+      const result = await handler.execute({ owner: 'owner', repo: 'repo' });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.alternatives).toBeDefined();
+        expect(result.data.alternatives).toHaveLength(2);
+        expect(result.data.alternatives![0].method).toBe('app');
+        expect(result.data.alternatives![1].method).toBe('token');
+      }
+    });
+
+    it('does not return alternatives when preferredMethod is set', async () => {
+      process.env.GITHUB_TOKEN = 'ghp_test123';
+      process.env.FLEET_APP_ID = '12345';
+      process.env.FLEET_APP_PRIVATE_KEY = 'base64key';
+      process.env.FLEET_APP_INSTALLATION_ID = '67890';
+
+      const handler = new AuthDetectHandler();
+      const result = await handler.execute({
+        owner: 'owner',
+        repo: 'repo',
+        preferredMethod: 'token',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.alternatives).toBeUndefined();
+      }
+    });
+  });
+
+  describe('health check failures', () => {
+    it('returns HEALTH_CHECK_FAILED on 401', async () => {
+      process.env.GITHUB_TOKEN = 'ghp_expired';
+      const { Octokit } = await import('octokit');
+      vi.mocked(Octokit).mockImplementation(() => ({
+        rest: {
+          repos: {
+            get: vi.fn().mockRejectedValue(Object.assign(new Error('Bad credentials'), { status: 401 })),
+          },
+          users: { getAuthenticated: vi.fn() },
+        },
+      }) as any);
+
+      const handler = new AuthDetectHandler();
+      const result = await handler.execute({ owner: 'owner', repo: 'repo' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe('HEALTH_CHECK_FAILED');
+        expect(result.error.details?.httpStatus).toBe(401);
+        expect(result.error.suggestion).toContain('invalid or expired');
+      }
+    });
+
+    it('returns HEALTH_CHECK_FAILED on 404', async () => {
+      process.env.GITHUB_TOKEN = 'ghp_valid';
+      const { Octokit } = await import('octokit');
+      vi.mocked(Octokit).mockImplementation(() => ({
+        rest: {
+          repos: {
+            get: vi.fn().mockRejectedValue(Object.assign(new Error('Not Found'), { status: 404 })),
+          },
+          users: { getAuthenticated: vi.fn() },
+        },
+      }) as any);
+
+      const handler = new AuthDetectHandler();
+      const result = await handler.execute({ owner: 'owner', repo: 'repo' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe('HEALTH_CHECK_FAILED');
+        expect(result.error.details?.httpStatus).toBe(404);
+        expect(result.error.suggestion).toContain('not found');
+      }
+    });
+  });
+
+  describe('no credentials', () => {
+    it('returns NO_CREDENTIALS_FOUND when nothing is available', async () => {
+      const { execSync } = await import('node:child_process');
+      vi.mocked(execSync).mockImplementation(() => { throw new Error('not found'); });
+
+      const handler = new AuthDetectHandler();
+      const result = await handler.execute({ owner: 'owner', repo: 'repo' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe('NO_CREDENTIALS_FOUND');
+        expect(result.error.recoverable).toBe(true);
+      }
+    });
+  });
+});

--- a/packages/fleet/src/__tests__/auth-detect-spec.test.ts
+++ b/packages/fleet/src/__tests__/auth-detect-spec.test.ts
@@ -1,0 +1,74 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import { AuthDetectInputSchema } from '../init/auth-detect/spec.js';
+
+describe('AuthDetectInputSchema', () => {
+  it('parses valid input with owner and repo', () => {
+    const result = AuthDetectInputSchema.safeParse({
+      owner: 'octocat',
+      repo: 'hello-world',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('parses valid input with preferredMethod', () => {
+    const result = AuthDetectInputSchema.safeParse({
+      owner: 'octocat',
+      repo: 'hello-world',
+      preferredMethod: 'app',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.preferredMethod).toBe('app');
+    }
+  });
+
+  it('rejects empty owner', () => {
+    const result = AuthDetectInputSchema.safeParse({
+      owner: '',
+      repo: 'hello-world',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty repo', () => {
+    const result = AuthDetectInputSchema.safeParse({
+      owner: 'octocat',
+      repo: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid preferredMethod', () => {
+    const result = AuthDetectInputSchema.safeParse({
+      owner: 'octocat',
+      repo: 'hello-world',
+      preferredMethod: 'invalid',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('allows preferredMethod to be omitted', () => {
+    const result = AuthDetectInputSchema.safeParse({
+      owner: 'octocat',
+      repo: 'hello-world',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.preferredMethod).toBeUndefined();
+    }
+  });
+});

--- a/packages/fleet/src/__tests__/init-wizard.test.ts
+++ b/packages/fleet/src/__tests__/init-wizard.test.ts
@@ -25,6 +25,14 @@ vi.mock('../shared/auth/git.js', () => ({
   }),
 }));
 
+// Mock AuthDetectHandler to avoid real network calls
+const mockExecute = vi.fn();
+vi.mock('../init/auth-detect/handler.js', () => ({
+  AuthDetectHandler: vi.fn().mockImplementation(() => ({
+    execute: mockExecute,
+  })),
+}));
+
 describe('validateHeadlessInputs (Non-Interactive Mode)', () => {
   const originalEnv = { ...process.env };
 
@@ -37,6 +45,12 @@ describe('validateHeadlessInputs (Non-Interactive Mode)', () => {
     delete process.env.GITHUB_APP_INSTALLATION_ID;
     delete process.env.GITHUB_REPOSITORY;
     delete process.env.JULES_API_KEY;
+
+    // Default: AuthDetectHandler returns successful token auth
+    mockExecute.mockResolvedValue({
+      success: true,
+      data: { method: 'token', source: 'env', identity: 'testuser' },
+    });
   });
 
   afterEach(() => {
@@ -82,6 +96,15 @@ describe('validateHeadlessInputs (Non-Interactive Mode)', () => {
   });
 
   it('fails when no auth is configured', async () => {
+    mockExecute.mockResolvedValue({
+      success: false,
+      error: {
+        code: 'NO_CREDENTIALS_FOUND',
+        message: 'No credentials found.',
+        suggestion: 'Set GITHUB_TOKEN or install GitHub CLI (gh auth login).',
+        recoverable: true,
+      },
+    });
     const events: FleetEvent[] = [];
     const result = await validateHeadlessInputs(
       { repo: 'o/r' },
@@ -92,8 +115,7 @@ describe('validateHeadlessInputs (Non-Interactive Mode)', () => {
     if ('success' in result) {
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error.message).toContain('Missing GitHub authentication');
-        expect(result.error.message).toContain('--non-interactive');
+        expect(result.error.message).toContain('No credentials found');
       }
     }
   });
@@ -117,6 +139,10 @@ describe('validateHeadlessInputs (Non-Interactive Mode)', () => {
   });
 
   it('detects GitHub App auth from env vars', async () => {
+    mockExecute.mockResolvedValue({
+      success: true,
+      data: { method: 'app', source: 'env', identity: 'fleet-app' },
+    });
     process.env.GITHUB_APP_ID = '123';
     process.env.GITHUB_APP_PRIVATE_KEY_BASE64 = 'key';
     process.env.GITHUB_APP_INSTALLATION_ID = '456';
@@ -132,6 +158,10 @@ describe('validateHeadlessInputs (Non-Interactive Mode)', () => {
   });
 
   it('--app-id flag overrides GITHUB_APP_ID env var', async () => {
+    mockExecute.mockResolvedValue({
+      success: true,
+      data: { method: 'app', source: 'env', identity: 'fleet-app' },
+    });
     process.env.GITHUB_APP_PRIVATE_KEY_BASE64 = 'key';
     process.env.GITHUB_APP_INSTALLATION_ID = '456';
     const events: FleetEvent[] = [];

--- a/packages/fleet/src/init/auth-detect/handler.ts
+++ b/packages/fleet/src/init/auth-detect/handler.ts
@@ -1,0 +1,231 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { execSync } from 'node:child_process';
+import { Octokit } from 'octokit';
+import { createAppAuth } from '@octokit/auth-app';
+import { resolvePrivateKey } from '../../shared/auth/resolve-key.js';
+import type {
+  AuthDetectSpec,
+  AuthDetectInput,
+  AuthDetectResult,
+  DetectedCredential,
+} from './spec.js';
+
+/**
+ * AuthDetectHandler discovers credentials from env vars and gh CLI,
+ * validates them against the target repo, and respects --auth intent.
+ *
+ * Never throws — all errors are Result values.
+ */
+export class AuthDetectHandler implements AuthDetectSpec {
+  async execute(input: AuthDetectInput): Promise<AuthDetectResult> {
+    try {
+      const { owner, repo, preferredMethod } = input;
+      const detected: DetectedCredential[] = [];
+
+      // ── 1. Detect available credentials, gated by preferredMethod ──
+
+      const hasToken = !!process.env.GITHUB_TOKEN;
+      const hasApp = this.hasAppCredentials();
+
+      // Only check sources matching the user's intent
+      if (preferredMethod !== 'token' && hasApp) {
+        detected.push({ method: 'app', source: 'env' });
+      }
+      if (preferredMethod !== 'app' && hasToken) {
+        detected.push({ method: 'token', source: 'env' });
+      }
+
+      // Fallback: try gh CLI for token auth (only if token not already found)
+      if (preferredMethod !== 'app' && !hasToken) {
+        const ghToken = this.tryGhCliToken();
+        if (ghToken) {
+          process.env.GITHUB_TOKEN = ghToken;
+          detected.push({ method: 'token', source: 'gh-cli' });
+        }
+      }
+
+      // ── 2. No credentials found ──
+      if (detected.length === 0) {
+        const methodHint = preferredMethod
+          ? `for ${preferredMethod} auth`
+          : '';
+        return {
+          success: false,
+          error: {
+            code: 'NO_CREDENTIALS_FOUND',
+            message: `No credentials found ${methodHint}`.trim() + '.',
+            suggestion: preferredMethod === 'app'
+              ? 'Set FLEET_APP_ID + FLEET_APP_PRIVATE_KEY + FLEET_APP_INSTALLATION_ID in your environment.'
+              : preferredMethod === 'token'
+                ? 'Set GITHUB_TOKEN or install GitHub CLI (gh auth login).'
+                : 'Set GITHUB_TOKEN, install GitHub CLI (gh auth login), or set FLEET_APP_* vars for app auth.',
+            recoverable: true,
+          },
+        };
+      }
+
+      // ── 3. Pick the credential to health-check ──
+      // If user has a preference, use that. Otherwise pick the first detected.
+      let active: DetectedCredential;
+      if (preferredMethod) {
+        const match = detected.find(d => d.method === preferredMethod);
+        active = match ?? detected[0];
+      } else {
+        active = detected[0];
+      }
+
+      // ── 4. Health check against target repo ──
+      const healthResult = await this.healthCheck(active.method, owner, repo);
+      if (!healthResult.ok) {
+        return healthResult.result;
+      }
+      const { identity } = healthResult;
+
+      // ── 5. Return success with alternatives for wizard ──
+      const alternatives = detected.length > 1 && !preferredMethod
+        ? detected
+        : undefined;
+
+      return {
+        success: true,
+        data: {
+          method: active.method,
+          source: active.source,
+          identity,
+          alternatives,
+        },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          code: 'UNKNOWN_ERROR',
+          message: error instanceof Error ? error.message : String(error),
+          recoverable: false,
+        },
+      };
+    }
+  }
+
+  // ── Private helpers ──
+
+  private hasAppCredentials(): boolean {
+    const appId = process.env.FLEET_APP_ID || process.env.GITHUB_APP_ID;
+    const privateKey = process.env.FLEET_APP_PRIVATE_KEY
+      || process.env.FLEET_APP_PRIVATE_KEY_BASE64
+      || process.env.GITHUB_APP_PRIVATE_KEY_BASE64
+      || process.env.GITHUB_APP_PRIVATE_KEY;
+    const installationId = process.env.FLEET_APP_INSTALLATION_ID || process.env.GITHUB_APP_INSTALLATION_ID;
+    return !!(appId && privateKey && installationId);
+  }
+
+  /**
+   * Try to get a GitHub token from the gh CLI credential store.
+   * Returns null if gh is not installed or no token is available.
+   */
+  private tryGhCliToken(): string | null {
+    try {
+      const result = execSync('gh auth token 2>/dev/null', {
+        encoding: 'utf-8',
+        timeout: 5000,
+      }).trim();
+      return result || null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Verify credentials work against the target repo.
+   * Returns identity on success, structured error on failure.
+   */
+  private async healthCheck(
+    method: 'token' | 'app',
+    owner: string,
+    repo: string,
+  ): Promise<{ ok: true; identity: string } | { ok: false; result: AuthDetectResult }> {
+    try {
+      const octokit = method === 'app'
+        ? this.createAppOctokit()
+        : new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+      // Check repo access — this validates both auth AND permissions
+      const { data: repoData } = await octokit.rest.repos.get({ owner, repo });
+
+      // Get identity
+      let identity: string;
+      if (method === 'token') {
+        const { data: user } = await octokit.rest.users.getAuthenticated();
+        identity = user.login;
+      } else {
+        identity = `app with access to ${repoData.full_name}`;
+      }
+
+      return { ok: true, identity };
+    } catch (error: any) {
+      const status = error?.status;
+      const message = error instanceof Error ? error.message : String(error);
+
+      let suggestion: string;
+      if (status === 401) {
+        suggestion = method === 'token'
+          ? 'Token is invalid or expired. Run `gh auth login` or set a new GITHUB_TOKEN.'
+          : 'App credentials are invalid. Check FLEET_APP_ID, FLEET_APP_PRIVATE_KEY, and FLEET_APP_INSTALLATION_ID.';
+      } else if (status === 403) {
+        suggestion = 'Token lacks required permissions. Ensure the token has `repo` scope.';
+      } else if (status === 404) {
+        suggestion = `Repository ${owner}/${repo} not found, or token lacks access. Check repo name and token scopes.`;
+      } else {
+        suggestion = `Unexpected error (HTTP ${status ?? 'unknown'}): ${message}`;
+      }
+
+      return {
+        ok: false,
+        result: {
+          success: false,
+          error: {
+            code: 'HEALTH_CHECK_FAILED',
+            message: `Auth health check failed for ${method} auth: ${message}`,
+            suggestion,
+            recoverable: true,
+            details: {
+              httpStatus: status,
+              repoAccess: false,
+            },
+          },
+        },
+      };
+    }
+  }
+
+  private createAppOctokit(): Octokit {
+    const appId = process.env.FLEET_APP_ID || process.env.GITHUB_APP_ID;
+    const privateKeyBase64 = process.env.FLEET_APP_PRIVATE_KEY
+      || process.env.FLEET_APP_PRIVATE_KEY_BASE64
+      || process.env.GITHUB_APP_PRIVATE_KEY_BASE64;
+    const privateKeyRaw = process.env.GITHUB_APP_PRIVATE_KEY;
+    const installationId = process.env.FLEET_APP_INSTALLATION_ID || process.env.GITHUB_APP_INSTALLATION_ID;
+
+    return new Octokit({
+      authStrategy: createAppAuth,
+      auth: {
+        appId,
+        privateKey: resolvePrivateKey(privateKeyBase64, privateKeyRaw),
+        installationId: Number(installationId),
+      },
+    });
+  }
+}

--- a/packages/fleet/src/init/auth-detect/index.ts
+++ b/packages/fleet/src/init/auth-detect/index.ts
@@ -1,0 +1,26 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export { AuthDetectHandler } from './handler.js';
+export type {
+  AuthDetectSpec,
+  AuthDetectInput,
+  AuthDetectResult,
+  AuthDetectSuccess,
+  AuthDetectFailure,
+  AuthDetectErrorCode,
+  AuthSource,
+  DetectedCredential,
+} from './spec.js';
+export { AuthDetectInputSchema } from './spec.js';

--- a/packages/fleet/src/init/auth-detect/spec.ts
+++ b/packages/fleet/src/init/auth-detect/spec.ts
@@ -1,0 +1,78 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { z } from 'zod';
+
+// ── INPUT ──
+
+export const AuthDetectInputSchema = z.object({
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  /** If set, only check credentials for that method — never eagerly pick the other */
+  preferredMethod: z.enum(['token', 'app']).optional(),
+});
+export type AuthDetectInput = z.infer<typeof AuthDetectInputSchema>;
+
+// ── ERROR CODES ──
+
+export const AuthDetectErrorCode = z.enum([
+  'NO_CREDENTIALS_FOUND',
+  'HEALTH_CHECK_FAILED',
+  'UNKNOWN_ERROR',
+]);
+export type AuthDetectErrorCode = z.infer<typeof AuthDetectErrorCode>;
+
+// ── RESULT ──
+
+export type AuthSource = 'env' | 'gh-cli' | 'manual';
+
+export interface DetectedCredential {
+  method: 'token' | 'app';
+  source: AuthSource;
+}
+
+export interface AuthDetectSuccess {
+  success: true;
+  data: {
+    method: 'token' | 'app';
+    source: AuthSource;
+    identity: string;
+    /** When both methods are detected and no preference — let wizard ask */
+    alternatives?: DetectedCredential[];
+  };
+}
+
+export interface AuthDetectFailure {
+  success: false;
+  error: {
+    code: AuthDetectErrorCode;
+    message: string;
+    suggestion?: string;
+    recoverable: boolean;
+    /** Structured details for LLM analysis */
+    details?: {
+      httpStatus?: number;
+      scopes?: string[];
+      repoAccess?: boolean;
+    };
+  };
+}
+
+export type AuthDetectResult = AuthDetectSuccess | AuthDetectFailure;
+
+// ── INTERFACE ──
+
+export interface AuthDetectSpec {
+  execute(input: AuthDetectInput): Promise<AuthDetectResult>;
+}

--- a/packages/fleet/src/init/wizard/headless.ts
+++ b/packages/fleet/src/init/wizard/headless.ts
@@ -47,40 +47,28 @@ export async function validateHeadlessInputs(
   }
 
   // ── Authentication ──
-  const hasToken = !!process.env.GITHUB_TOKEN;
-  const hasApp = !!(
-    (args['app-id'] || process.env.GITHUB_APP_ID) &&
-    (process.env.GITHUB_APP_PRIVATE_KEY_BASE64 || process.env.GITHUB_APP_PRIVATE_KEY) &&
-    (args['installation-id'] || process.env.GITHUB_APP_INSTALLATION_ID)
-  );
+  // Apply CLI overrides to env before detection
+  if (args['app-id']) process.env.GITHUB_APP_ID = args['app-id'];
+  if (args['installation-id']) process.env.GITHUB_APP_INSTALLATION_ID = args['installation-id'];
+
+  const { AuthDetectHandler } = await import('../auth-detect/handler.js');
+  const detector = new AuthDetectHandler();
+  const detectResult = await detector.execute({
+    owner,
+    repo,
+    preferredMethod: args.auth === 'token' || args.auth === 'app' ? args.auth : undefined,
+  });
 
   let authMethod: 'token' | 'app';
-
-  if (args.auth === 'app' || (!args.auth && hasApp)) {
-    authMethod = 'app';
-    if (args['app-id']) process.env.GITHUB_APP_ID = args['app-id'];
-    if (args['installation-id']) process.env.GITHUB_APP_INSTALLATION_ID = args['installation-id'];
-    if (!hasApp) {
-      const missing: string[] = [];
-      if (!process.env.GITHUB_APP_ID && !args['app-id']) missing.push('GITHUB_APP_ID (env) or --app-id');
-      if (!process.env.GITHUB_APP_PRIVATE_KEY_BASE64 && !process.env.GITHUB_APP_PRIVATE_KEY) {
-        missing.push('GITHUB_APP_PRIVATE_KEY_BASE64 (env)');
-      }
-      if (!process.env.GITHUB_APP_INSTALLATION_ID && !args['installation-id']) {
-        missing.push('GITHUB_APP_INSTALLATION_ID (env) or --installation-id');
-      }
-      return fail(
-        'UNKNOWN_ERROR',
-        `Missing GitHub App credentials: ${missing.join(', ')}.\nOr run without --non-interactive for guided setup.`,
-        true,
-      );
-    }
-  } else if (args.auth === 'token' || (!args.auth && hasToken)) {
-    authMethod = 'token';
+  if (detectResult.success) {
+    authMethod = detectResult.data.method;
+    emit({ type: 'init:auth:detected', method: authMethod });
   } else {
+    const errMsg = detectResult.error.message;
+    const suggestion = detectResult.error.suggestion ?? 'Or run without --non-interactive for guided setup.';
     return fail(
       'UNKNOWN_ERROR',
-      'Missing GitHub authentication.\nSet GITHUB_TOKEN or GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY_BASE64 + GITHUB_APP_INSTALLATION_ID.\nOr run without --non-interactive for guided setup.',
+      `${errMsg}\n${suggestion}`,
       true,
     );
   }

--- a/packages/fleet/src/init/wizard/interactive.ts
+++ b/packages/fleet/src/init/wizard/interactive.ts
@@ -85,40 +85,57 @@ export async function runInitWizard(
   const baseBranch = args.base ?? 'main';
 
   // ── Step 3: Authentication ──
-  const hasToken = !!process.env.GITHUB_TOKEN;
-  const hasApp = !!(process.env.GITHUB_APP_ID && (process.env.GITHUB_APP_PRIVATE_KEY_BASE64 || process.env.GITHUB_APP_PRIVATE_KEY) && process.env.GITHUB_APP_INSTALLATION_ID);
+  const { AuthDetectHandler } = await import('../auth-detect/handler.js');
+  const detector = new AuthDetectHandler();
+
+  const detectResult = await detector.execute({
+    owner,
+    repo,
+    preferredMethod: args.auth === 'token' || args.auth === 'app' ? args.auth : undefined,
+  });
 
   let authMethod: 'token' | 'app';
 
-  if (args.auth === 'token' || args.auth === 'app') {
-    authMethod = args.auth;
-  } else if (hasApp) {
-    const useApp = await p.confirm({
-      message: 'GitHub App credentials detected in environment. Use these?',
-      initialValue: true,
-    });
-    if (p.isCancel(useApp)) return fail('UNKNOWN_ERROR', 'Setup cancelled.', false);
-    if (useApp) {
-      authMethod = 'app';
+  if (detectResult.success) {
+    const { method, source, identity, alternatives } = detectResult.data;
+
+    // If both methods found and no preference, ask which to use
+    if (alternatives && alternatives.length > 1) {
+      const choice = await p.select({
+        message: `Multiple auth methods detected. Which to use?`,
+        options: alternatives.map(a => ({
+          value: a.method,
+          label: a.method === 'app'
+            ? `GitHub App (from ${a.source})`
+            : `Personal Access Token (from ${a.source})`,
+        })),
+      });
+      if (p.isCancel(choice)) return fail('UNKNOWN_ERROR', 'Setup cancelled.', false);
+      authMethod = choice;
     } else {
-      const chosen = await promptAuthMethod();
-      if (!chosen) return fail('UNKNOWN_ERROR', 'Setup cancelled.', false);
-      authMethod = chosen;
-    }
-  } else if (hasToken) {
-    const useToken = await p.confirm({
-      message: 'GITHUB_TOKEN detected in environment. Use this?',
-      initialValue: true,
-    });
-    if (p.isCancel(useToken)) return fail('UNKNOWN_ERROR', 'Setup cancelled.', false);
-    if (useToken) {
-      authMethod = 'token';
-    } else {
-      const chosen = await promptAuthMethod();
-      if (!chosen) return fail('UNKNOWN_ERROR', 'Setup cancelled.', false);
-      authMethod = chosen;
+      // Single method detected — confirm
+      const useDetected = await p.confirm({
+        message: `Authenticated as ${identity} via ${source} (${method}). Use this?`,
+        initialValue: true,
+      });
+      if (p.isCancel(useDetected)) return fail('UNKNOWN_ERROR', 'Setup cancelled.', false);
+      if (useDetected) {
+        authMethod = method;
+      } else {
+        const chosen = await promptAuthMethod();
+        if (!chosen) return fail('UNKNOWN_ERROR', 'Setup cancelled.', false);
+        authMethod = chosen;
+      }
     }
   } else {
+    // Detection failed — show why and fall through to manual flow
+    if (detectResult.error.code === 'HEALTH_CHECK_FAILED') {
+      p.log.warn(`Auth check failed: ${detectResult.error.message}`);
+      if (detectResult.error.suggestion) {
+        p.log.info(detectResult.error.suggestion);
+      }
+    }
+
     const authChoice = await p.select({
       message: 'How will Fleet authenticate with GitHub?',
       options: [
@@ -131,19 +148,16 @@ export async function runInitWizard(
 
     // Prompt for credentials
     if (authMethod === 'token') {
-      if (!hasToken) {
-        const token = await p.password({
-          message: 'Paste your GitHub token:',
-        });
-        if (p.isCancel(token)) return fail('UNKNOWN_ERROR', 'Setup cancelled.', false);
-        process.env.GITHUB_TOKEN = token;
-      }
+      const token = await p.password({
+        message: 'Paste your GitHub token:',
+      });
+      if (p.isCancel(token)) return fail('UNKNOWN_ERROR', 'Setup cancelled.', false);
+      process.env.GITHUB_TOKEN = token;
     } else {
       // ── GitHub App: slug → key file → auto-detect ──
       const { resolvePrivateKeyFromInput } = await import('../../shared/auth/resolve-key-input.js');
       const { resolveInstallation } = await import('../../shared/auth/resolve-installation.js');
 
-      // 1. App slug
       const slug = await p.text({
         message: 'What is your GitHub App slug? (from the URL: github.com/settings/apps/<slug>)',
         validate: (v) => !v?.trim() ? 'App slug is required' : undefined,
@@ -152,7 +166,6 @@ export async function runInitWizard(
 
       p.log.info(`Download your private key from: https://github.com/settings/apps/${slug}`);
 
-      // 2. Private key (file path, PEM, or base64)
       const keyInput = await p.text({
         message: 'Path to your private key (.pem file), or paste the key directly:',
         validate: (v) => !v?.trim() ? 'Private key is required' : undefined,
@@ -170,17 +183,12 @@ export async function runInitWizard(
         );
       }
 
-      // 3. Auto-detect App ID and Installation ID
       const s = p.spinner();
       s.start(`Authenticating as "${slug}" and finding installation for ${owner}/${repo}...`);
 
       try {
-        // We need the app ID — get it from the API using the slug
-        // First, authenticate as the app to discover its ID
         const { Octokit } = await import('octokit');
-        const { createAppAuth } = await import('@octokit/auth-app');
 
-        // Use slug to look up the app's ID via the public endpoint
         const tempOctokit = new Octokit();
         const { data: appData } = await tempOctokit.rest.apps.getBySlug({ app_slug: slug });
         if (!appData) {
@@ -193,7 +201,6 @@ export async function runInitWizard(
         s.stop(`Authenticated as "${resolved.appName}" (ID: ${resolved.appId})`);
         p.log.success(`Found installation for ${resolved.accountLogin} (ID: ${resolved.installationId})`);
 
-        // Set env vars for downstream use
         process.env.GITHUB_APP_ID = appId;
         process.env.GITHUB_APP_INSTALLATION_ID = String(resolved.installationId);
         process.env.GITHUB_APP_PRIVATE_KEY = privateKeyPem;


### PR DESCRIPTION
Multi-source credential detection (env vars → gh CLI) with:
- --auth flag gating: --auth=app never touches GITHUB_TOKEN
- Health check against target repo (GET /repos/{owner}/{repo})
- Structured error output for LLM analysis
- wizard shows alternatives when both methods found

17 new tests + 5 updated existing tests