### PR TITLE
fix(fleet): use mergeable field to distinguish 422 conflicts from up-to date

### DIFF
--- a/packages/fleet/src/__tests__/merge-handler.test.ts
+++ b/packages/fleet/src/__tests__/merge-handler.test.ts
@@ -246,7 +246,7 @@ describe('MergeHandler (Logic Tests)', () => {
           data: [makePR(28, ['fleet-merge-ready'])],
         }),
         get: vi.fn().mockResolvedValue({
-          data: { head: { sha: 'abc123' } },
+          data: { head: { sha: 'abc123' }, mergeable: false },
         }),
         merge: vi.fn(),
         updateBranch: vi.fn().mockRejectedValue(conflictError),
@@ -281,7 +281,7 @@ describe('MergeHandler (Logic Tests)', () => {
           data: [makePR(28, ['fleet-merge-ready'])],
         }),
         get: vi.fn().mockResolvedValue({
-          data: { head: { sha: 'abc123' } },
+          data: { head: { sha: 'abc123' }, mergeable: false },
         }),
         // Close old PR during redispatch
         update: vi.fn().mockResolvedValue({ data: {} }),
@@ -315,5 +315,77 @@ describe('MergeHandler (Logic Tests)', () => {
       expect(result.error.code).toBe('CONFLICT_RETRIES_EXHAUSTED');
     }
   });
-});
 
+  it('treats 422 "already up to date" as success, not conflict', async () => {
+    const alreadyUpToDateError = new Error('Validation Failed') as any;
+    alreadyUpToDateError.status = 422;
+
+    const octokit = createMockOctokit({
+      pulls: {
+        list: vi.fn().mockResolvedValue({
+          data: [makePR(46, ['fleet-merge-ready'])],
+        }),
+        get: vi.fn().mockResolvedValue({
+          data: { head: { sha: 'sha-46' }, mergeable: true },
+        }),
+        merge: vi.fn().mockResolvedValue({ data: {} }),
+        updateBranch: vi.fn().mockRejectedValue(alreadyUpToDateError),
+      },
+      checks: {
+        listForRef: vi.fn().mockResolvedValue({
+          data: { check_runs: [] },
+        }),
+      },
+    });
+
+    const handler = new MergeHandler({ octokit, sleep: noopSleep });
+    const result = await handler.execute(baseInput);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // PR should have been merged, not skipped or redispatched
+      expect(result.data.merged).toEqual([46]);
+      expect(result.data.skipped).toHaveLength(0);
+      expect(result.data.redispatched).toHaveLength(0);
+    }
+    // Merge SHOULD have been called
+    expect(octokit.rest.pulls.merge).toHaveBeenCalledWith(
+      expect.objectContaining({ pull_number: 46 }),
+    );
+  });
+
+  it('still detects real 422 merge conflicts', async () => {
+    const conflictError = new Error('Validation Failed') as any;
+    conflictError.status = 422;
+
+    const octokit = createMockOctokit({
+      pulls: {
+        list: vi.fn().mockResolvedValue({
+          data: [makePR(47, ['fleet-merge-ready'])],
+        }),
+        get: vi.fn().mockResolvedValue({
+          data: { head: { sha: 'sha-47' }, mergeable: false },
+        }),
+        merge: vi.fn(),
+        updateBranch: vi.fn().mockRejectedValue(conflictError),
+      },
+      checks: {
+        listForRef: vi.fn().mockResolvedValue({
+          data: { check_runs: [] },
+        }),
+      },
+    });
+
+    const handler = new MergeHandler({ octokit, sleep: noopSleep });
+    const result = await handler.execute(baseInput);
+
+    // Should still be treated as a conflict (reDispatch is off by default)
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe('CONFLICT_RETRIES_EXHAUSTED');
+      expect(result.error.message).toContain('PR #47');
+    }
+    // Merge should NOT have been attempted
+    expect(octokit.rest.pulls.merge).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fleet/src/merge/handler.ts
+++ b/packages/fleet/src/merge/handler.ts
@@ -98,6 +98,7 @@ export class MergeHandler implements MergeSpec {
             input.repo,
             currentPr.number,
             this.emit,
+            this.sleep,
           );
 
           if (!updateResult.ok && updateResult.conflict) {

--- a/packages/fleet/src/merge/ops/update-branch.ts
+++ b/packages/fleet/src/merge/ops/update-branch.ts
@@ -15,6 +15,10 @@
 import type { Octokit } from 'octokit';
 import type { FleetEmitter } from '../../shared/events.js';
 
+/** Max polls waiting for GitHub to compute mergeable state */
+const MERGEABLE_POLL_LIMIT = 5;
+const MERGEABLE_POLL_INTERVAL_MS = 2_000;
+
 /**
  * Updates a PR branch from its base branch.
  * Returns conflict status so the caller can decide to re-dispatch.
@@ -25,6 +29,7 @@ export async function updateBranch(
   repo: string,
   prNumber: number,
   emit: FleetEmitter,
+  sleep: (ms: number) => Promise<void> = (ms) => new Promise((r) => setTimeout(r, ms)),
 ): Promise<{ ok: boolean; conflict: boolean; error?: string }> {
   try {
     emit({ type: 'merge:branch:updating', prNumber });
@@ -41,11 +46,46 @@ export async function updateBranch(
         ? (error as { status: number }).status
         : 0;
     if (status === 422) {
-      emit({ type: 'merge:conflict:detected', prNumber });
-      return { ok: false, conflict: true };
+      // 422 is ambiguous — could be "already up to date" or a real conflict.
+      // Use `pulls.get().mergeable` as the definitive signal.
+      const conflict = await isMergeConflict(octokit, owner, repo, prNumber, sleep);
+      if (conflict) {
+        emit({ type: 'merge:conflict:detected', prNumber });
+        return { ok: false, conflict: true };
+      }
+      // Not a conflict (e.g., already up to date) — treat as success.
+      emit({ type: 'merge:branch:updated', prNumber });
+      return { ok: true, conflict: false };
     }
     const message =
       error instanceof Error ? error.message : String(error);
     return { ok: false, conflict: false, error: message };
   }
 }
+
+/**
+ * Checks whether a PR has a merge conflict using GitHub's `mergeable` field.
+ * Polls if `mergeable` is null (GitHub is still computing).
+ */
+async function isMergeConflict(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  sleep: (ms: number) => Promise<void>,
+): Promise<boolean> {
+  for (let i = 0; i < MERGEABLE_POLL_LIMIT; i++) {
+    const { data: pr } = await octokit.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: prNumber,
+    });
+    if (pr.mergeable === true) return false;
+    if (pr.mergeable === false) return true;
+    // null = still computing, wait and retry
+    await sleep(MERGEABLE_POLL_INTERVAL_MS);
+  }
+  // If still null after polling, assume not a conflict to avoid false positives.
+  return false;
+}
+


### PR DESCRIPTION
`updateBranch` treated all 422 responses as merge conflicts, but GitHub also returns 422 when a branch is already up to date. This caused fleet-merge to incorrectly close and re-dispatch every PR.

Now when updateBranch gets a 422, we check `pulls.get().mergeable` as the definitive signal instead of parsing error message strings.