### PR TITLE
feat(fleet): smart merge with pre-merge overlap analysis and batch conflict resolution

### DIFF
--- a/packages/fleet/src/__tests__/batch-resolve.test.ts
+++ b/packages/fleet/src/__tests__/batch-resolve.test.ts
@@ -1,0 +1,310 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  batchResolveConflicts,
+  buildBatchPrompt,
+} from '../merge/ops/resolve-conflicts.js';
+import type { PR } from '../shared/schemas/pr.js';
+import type { BatchResolveInput } from '../merge/ops/resolve-conflicts.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function makePR(number: number, body?: string): PR {
+  return {
+    number,
+    headRef: `branch-${number}`,
+    headSha: `sha-${number}`,
+    body: body ?? `PR #${number} body`,
+  };
+}
+
+function makeInput(overrides?: Partial<BatchResolveInput>): BatchResolveInput {
+  return {
+    owner: 'testowner',
+    repo: 'testrepo',
+    baseBranch: 'main',
+    conflictingPRs: [makePR(1), makePR(2)],
+    sharedFiles: ['src/client.py'],
+    recentlyMerged: [10],
+    ...overrides,
+  };
+}
+
+function createMockOctokit(
+  diffsByPR: Record<number, string>,
+  diffFailures: number[] = [],
+  commentFailures: number[] = [],
+) {
+  const createComment = vi.fn().mockImplementation(({ issue_number }: any) => {
+    if (commentFailures.includes(issue_number)) {
+      throw new Error('Comment API error');
+    }
+    return Promise.resolve({ data: {} });
+  });
+
+  return {
+    rest: {
+      pulls: {
+        get: vi.fn().mockImplementation(({ pull_number }: any) => {
+          if (diffFailures.includes(pull_number)) {
+            throw new Error('Diff API error');
+          }
+          return Promise.resolve({
+            data: diffsByPR[pull_number] ?? '',
+          });
+        }),
+      },
+      issues: {
+        createComment,
+      },
+    },
+    _createComment: createComment,
+  } as any;
+}
+
+function createMockJulesProvider(sessionId = 'session-123', shouldFail = false) {
+  const sessionFn = vi.fn().mockImplementation(() => {
+    if (shouldFail) {
+      throw new Error('Jules API error');
+    }
+    return Promise.resolve({ id: sessionId });
+  });
+
+  return {
+    provider: vi.fn().mockResolvedValue({
+      session: sessionFn,
+    }) as any,
+    sessionFn,
+  };
+}
+
+const noopEmit = () => {};
+
+// ── buildBatchPrompt ────────────────────────────────────────────────
+
+describe('buildBatchPrompt', () => {
+  it('includes diff and recently merged PRs for a single conflicting PR', () => {
+    const input = makeInput({
+      conflictingPRs: [makePR(54, 'Fixes #43: test coverage')],
+      recentlyMerged: [52, 53],
+    });
+    const diffs = new Map([[54, '--- a/tests/test_client.py\n+++ b/tests/test_client.py']]);
+    const prompt = buildBatchPrompt(input, diffs);
+
+    expect(prompt).toContain('PR #54');
+    expect(prompt).toContain('Fixes #43');
+    expect(prompt).toContain('test_client.py');
+    expect(prompt).toContain('PR #52');
+    expect(prompt).toContain('PR #53');
+  });
+
+  it('includes both diffs and shared files for two conflicting PRs', () => {
+    const input = makeInput({
+      conflictingPRs: [makePR(54), makePR(55)],
+      sharedFiles: ['src/client.py', 'tests/test_client.py'],
+    });
+    const diffs = new Map([
+      [54, 'diff-54'],
+      [55, 'diff-55'],
+    ]);
+    const prompt = buildBatchPrompt(input, diffs);
+
+    expect(prompt).toContain('PR #54');
+    expect(prompt).toContain('PR #55');
+    expect(prompt).toContain('diff-54');
+    expect(prompt).toContain('diff-55');
+    expect(prompt).toContain('`src/client.py`');
+    expect(prompt).toContain('`tests/test_client.py`');
+  });
+
+  it('handles empty diffs gracefully', () => {
+    const input = makeInput({
+      conflictingPRs: [makePR(1)],
+    });
+    const diffs = new Map([[1, '']]);
+    const prompt = buildBatchPrompt(input, diffs);
+
+    expect(prompt).toContain('PR #1');
+    // Should not contain empty code block
+    expect(prompt).not.toContain('```diff\n\n```');
+  });
+
+  it('includes instructions to not duplicate work', () => {
+    const input = makeInput();
+    const prompt = buildBatchPrompt(input, new Map());
+
+    expect(prompt).toContain('Create ONE PR');
+    expect(prompt).toContain('Do NOT duplicate work');
+  });
+
+  it('handles no recently merged PRs', () => {
+    const input = makeInput({ recentlyMerged: [] });
+    const prompt = buildBatchPrompt(input, new Map());
+
+    expect(prompt).not.toContain('Recently Merged');
+  });
+});
+
+// ── batchResolveConflicts ───────────────────────────────────────────
+
+describe('batchResolveConflicts', () => {
+  it('dispatches exactly one session for a batch of N conflicting PRs', async () => {
+    const octokit = createMockOctokit({ 1: 'diff-1', 2: 'diff-2' });
+    const { provider, sessionFn } = createMockJulesProvider('session-abc');
+    const input = makeInput();
+
+    const result = await batchResolveConflicts(octokit, input, noopEmit, provider);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.sessionId).toBe('session-abc');
+      expect(result.resolvedPRs).toEqual([1, 2]);
+    }
+    // Jules session should be called exactly once
+    expect(sessionFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('targets correct repo and base branch', async () => {
+    const octokit = createMockOctokit({ 1: 'diff-1' });
+    const { provider, sessionFn } = createMockJulesProvider();
+    const input = makeInput({
+      owner: 'myorg',
+      repo: 'myrepo',
+      baseBranch: 'develop',
+      conflictingPRs: [makePR(1)],
+    });
+
+    await batchResolveConflicts(octokit, input, noopEmit, provider);
+
+    expect(sessionFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: { github: 'myorg/myrepo', baseBranch: 'develop' },
+        requireApproval: false,
+        autoPr: true,
+      }),
+    );
+  });
+
+  it('returns error on dispatch failure (does not throw)', async () => {
+    const octokit = createMockOctokit({ 1: 'diff-1' });
+    const { provider } = createMockJulesProvider('', true);
+    const input = makeInput({ conflictingPRs: [makePR(1)] });
+
+    const result = await batchResolveConflicts(octokit, input, noopEmit, provider);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('Jules API error');
+    }
+  });
+
+  it('still dispatches when diff fetch fails for one PR (non-fatal)', async () => {
+    const octokit = createMockOctokit({ 1: 'diff-1' }, [2]); // PR 2 diff fails
+    const { provider, sessionFn } = createMockJulesProvider('session-xyz');
+    const input = makeInput();
+
+    const result = await batchResolveConflicts(octokit, input, noopEmit, provider);
+
+    expect(result.success).toBe(true);
+    // Session should still be dispatched
+    expect(sessionFn).toHaveBeenCalledTimes(1);
+    // The prompt should still contain PR #2 even with empty diff
+    const promptArg = sessionFn.mock.calls[0][0].prompt;
+    expect(promptArg).toContain('PR #2');
+  });
+
+  it('does NOT close original PRs', async () => {
+    const octokit = createMockOctokit({ 1: 'diff-1', 2: 'diff-2' });
+    const { provider } = createMockJulesProvider();
+    const input = makeInput();
+
+    await batchResolveConflicts(octokit, input, noopEmit, provider);
+
+    // Verify pulls.update was never called (which would close PRs)
+    expect(octokit.rest.pulls.update).toBeUndefined();
+  });
+
+  it('adds comment to each original PR explaining batch resolution', async () => {
+    const octokit = createMockOctokit({ 1: 'diff-1', 2: 'diff-2' });
+    const { provider } = createMockJulesProvider('session-123');
+    const input = makeInput();
+
+    await batchResolveConflicts(octokit, input, noopEmit, provider);
+
+    const createComment = octokit._createComment;
+    expect(createComment).toHaveBeenCalledTimes(2);
+
+    // Check first call
+    const firstCall = createComment.mock.calls[0][0];
+    expect(firstCall.issue_number).toBe(1);
+    expect(firstCall.body).toContain('Batch conflict resolution');
+    expect(firstCall.body).toContain('#1');
+    expect(firstCall.body).toContain('#2');
+    expect(firstCall.body).toContain('session-123');
+
+    // Check second call
+    const secondCall = createComment.mock.calls[1][0];
+    expect(secondCall.issue_number).toBe(2);
+  });
+
+  it('succeeds even when commenting fails (non-fatal)', async () => {
+    const octokit = createMockOctokit({ 1: 'diff-1', 2: 'diff-2' }, [], [1, 2]);
+    const { provider } = createMockJulesProvider('session-abc');
+    const input = makeInput();
+
+    const result = await batchResolveConflicts(octokit, input, noopEmit, provider);
+
+    // Should still succeed — comments are non-fatal
+    expect(result.success).toBe(true);
+  });
+
+  it('emits start and done events', async () => {
+    const octokit = createMockOctokit({ 1: 'diff-1' });
+    const { provider } = createMockJulesProvider('session-xyz');
+    const events: any[] = [];
+    const emit = (e: any) => events.push(e);
+    const input = makeInput({ conflictingPRs: [makePR(1)] });
+
+    await batchResolveConflicts(octokit, input, emit, provider);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'merge:batch-resolve:start' }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'merge:batch-resolve:done',
+        sessionId: 'session-xyz',
+      }),
+    );
+  });
+
+  it('emits error event on dispatch failure', async () => {
+    const octokit = createMockOctokit({ 1: 'diff-1' });
+    const { provider } = createMockJulesProvider('', true);
+    const events: any[] = [];
+    const emit = (e: any) => events.push(e);
+    const input = makeInput({ conflictingPRs: [makePR(1)] });
+
+    await batchResolveConflicts(octokit, input, emit, provider);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'error',
+        code: 'BATCH_RESOLVE_FAILED',
+      }),
+    );
+  });
+});

--- a/packages/fleet/src/__tests__/merge-handler.test.ts
+++ b/packages/fleet/src/__tests__/merge-handler.test.ts
@@ -46,7 +46,8 @@ const baseInput: MergeInput = {
   mode: 'label',
   baseBranch: 'main',
   admin: false,
-  reDispatch: false,
+  redispatch: false,
+
   maxCIWaitSeconds: 1,
   maxRetries: 2,
   pollTimeoutSeconds: 1,
@@ -261,7 +262,7 @@ describe('MergeHandler (Logic Tests)', () => {
     const handler = new MergeHandler({ octokit, sleep: noopSleep });
     const result = await handler.execute(baseInput);
 
-    // Without re-dispatch, should return conflict error (not MERGE_FAILED)
+    // Without redispatch, should return conflict error (not MERGE_FAILED)
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.code).toBe('CONFLICT_RETRIES_EXHAUSTED');
@@ -271,7 +272,7 @@ describe('MergeHandler (Logic Tests)', () => {
     expect(octokit.rest.pulls.merge).not.toHaveBeenCalled();
   });
 
-  it('re-dispatches first (only) PR on conflict when reDispatch is enabled', async () => {
+  it('handles conflict via batch path when redispatch is enabled', async () => {
     const conflictError = new Error('Conflict') as any;
     conflictError.status = 422;
 
@@ -280,40 +281,56 @@ describe('MergeHandler (Logic Tests)', () => {
         list: vi.fn().mockResolvedValue({
           data: [makePR(28, ['fleet-merge-ready'])],
         }),
-        get: vi.fn().mockResolvedValue({
-          data: { head: { sha: 'abc123' }, mergeable: false },
+        get: vi.fn().mockImplementation(({ mediaType }: any) => {
+          if (mediaType?.format === 'diff') {
+            return { data: 'diff content' };
+          }
+          return { data: { head: { sha: 'abc123' }, mergeable: false } };
         }),
-        // Close old PR during redispatch
         update: vi.fn().mockResolvedValue({ data: {} }),
-        // updateBranch always returns conflict (simulates persistent conflict)
         updateBranch: vi.fn().mockRejectedValue(conflictError),
         merge: vi.fn(),
+        listFiles: vi.fn().mockResolvedValue({
+          data: [{ filename: 'src/client.py' }],
+        }),
       },
       checks: {
         listForRef: vi.fn().mockResolvedValue({
           data: { check_runs: [] },
         }),
       },
+      issues: {
+        createComment: vi.fn().mockResolvedValue({ data: {} }),
+      },
     });
+
+    // Mock the jules import for batch resolve
+    vi.doMock('@google/jules-sdk', () => ({
+      jules: {
+        session: vi.fn().mockResolvedValue({ id: 'batch-session-28' }),
+      },
+    }));
 
     const handler = new MergeHandler({ octokit, sleep: noopSleep });
     const result = await handler.execute({
       ...baseInput,
-      reDispatch: true,
-      maxRetries: 0, // Exhaust immediately after first conflict to avoid infinite loop
+      redispatch: true,
+      maxRetries: 0,
     });
 
-    // updateBranch should have been called for the first PR
+    // updateBranch should have been called
     expect(octokit.rest.pulls.updateBranch).toHaveBeenCalledWith(
       expect.objectContaining({ pull_number: 28 }),
     );
     // Merge should NOT have been attempted
     expect(octokit.rest.pulls.merge).not.toHaveBeenCalled();
-    // Should fail after exhausting retries
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.code).toBe('CONFLICT_RETRIES_EXHAUSTED');
+    // With batch path, result is success with the PR in skipped/redispatched
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.skipped).toContain(28);
     }
+
+    vi.doUnmock('@google/jules-sdk');
   });
 
   it('treats 422 "already up to date" as success, not conflict', async () => {
@@ -379,7 +396,7 @@ describe('MergeHandler (Logic Tests)', () => {
     const handler = new MergeHandler({ octokit, sleep: noopSleep });
     const result = await handler.execute(baseInput);
 
-    // Should still be treated as a conflict (reDispatch is off by default)
+    // Should still be treated as a conflict (redispatch is off by default)
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.code).toBe('CONFLICT_RETRIES_EXHAUSTED');
@@ -387,5 +404,222 @@ describe('MergeHandler (Logic Tests)', () => {
     }
     // Merge should NOT have been attempted
     expect(octokit.rest.pulls.merge).not.toHaveBeenCalled();
+  });
+});
+
+describe('MergeHandler (Batch Mode Tests)', () => {
+  const batchInput: MergeInput = {
+    ...baseInput,
+    redispatch: true,
+    maxRetries: 0,
+  };
+
+  it('emits merge:plan:computed when batch mode is enabled', async () => {
+    const octokit = createMockOctokit({
+      pulls: {
+        list: vi.fn().mockResolvedValue({
+          data: [
+            makePR(1, ['fleet-merge-ready']),
+            makePR(2, ['fleet-merge-ready']),
+          ],
+        }),
+        get: vi.fn().mockResolvedValue({
+          data: { head: { sha: 'abc123' } },
+        }),
+        merge: vi.fn().mockResolvedValue({ data: {} }),
+        updateBranch: vi.fn().mockResolvedValue({ data: {} }),
+        listFiles: vi.fn().mockImplementation(({ pull_number }: any) => {
+          if (pull_number === 1) return { data: [{ filename: 'a.py' }] };
+          return { data: [{ filename: 'b.py' }] };
+        }),
+      },
+      checks: {
+        listForRef: vi.fn().mockResolvedValue({ data: { check_runs: [] } }),
+      },
+    });
+
+    const events: any[] = [];
+    const handler = new MergeHandler({
+      octokit,
+      sleep: noopSleep,
+      emit: (e: any) => events.push(e),
+    });
+    await handler.execute(batchInput);
+
+    const planEvent = events.find((e) => e.type === 'merge:plan:computed');
+    expect(planEvent).toBeDefined();
+    expect(planEvent.independent.sort()).toEqual([1, 2]);
+    expect(planEvent.conflictGroups).toEqual([]);
+  });
+
+  it('merges independent PRs before conflict groups', async () => {
+    const mergeOrder: number[] = [];
+    const octokit = createMockOctokit({
+      pulls: {
+        list: vi.fn().mockResolvedValue({
+          data: [
+            makePR(1, ['fleet-merge-ready']),
+            makePR(2, ['fleet-merge-ready']),
+            makePR(3, ['fleet-merge-ready']),
+          ],
+        }),
+        get: vi.fn().mockResolvedValue({
+          data: { head: { sha: 'abc123' }, mergeable: false },
+        }),
+        merge: vi.fn().mockImplementation(({ pull_number }: any) => {
+          mergeOrder.push(pull_number);
+          return { data: {} };
+        }),
+        update: vi.fn().mockResolvedValue({ data: {} }),
+        updateBranch: vi.fn().mockResolvedValue({ data: {} }),
+        listFiles: vi.fn().mockImplementation(({ pull_number }: any) => {
+          if (pull_number === 1) return { data: [{ filename: 'isolated.md' }] };
+          if (pull_number === 2) return { data: [{ filename: 'shared.py' }] };
+          return { data: [{ filename: 'shared.py' }] };
+        }),
+      },
+      checks: {
+        listForRef: vi.fn().mockResolvedValue({ data: { check_runs: [] } }),
+      },
+      issues: {
+        createComment: vi.fn().mockResolvedValue({ data: {} }),
+      },
+    });
+
+    const handler = new MergeHandler({ octokit, sleep: noopSleep });
+    const result = await handler.execute(batchInput);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // PR 1 is independent and should be merged first
+      expect(result.data.merged[0]).toBe(1);
+    }
+  });
+
+  it('given PRs ordered [A(3 files), B(1 file), C(2 files)] independent, merges B→C→A', async () => {
+    const mergeOrder: number[] = [];
+    const octokit = createMockOctokit({
+      pulls: {
+        list: vi.fn().mockResolvedValue({
+          data: [
+            makePR(1, ['fleet-merge-ready']),
+            makePR(2, ['fleet-merge-ready']),
+            makePR(3, ['fleet-merge-ready']),
+          ],
+        }),
+        get: vi.fn().mockResolvedValue({
+          data: { head: { sha: 'abc123' } },
+        }),
+        merge: vi.fn().mockImplementation(({ pull_number }: any) => {
+          mergeOrder.push(pull_number);
+          return { data: {} };
+        }),
+        updateBranch: vi.fn().mockResolvedValue({ data: {} }),
+        listFiles: vi.fn().mockImplementation(({ pull_number }: any) => {
+          if (pull_number === 1) return { data: [{ filename: 'a.py' }, { filename: 'b.py' }, { filename: 'c.py' }] };
+          if (pull_number === 2) return { data: [{ filename: 'd.py' }] };
+          return { data: [{ filename: 'e.py' }, { filename: 'f.py' }] };
+        }),
+      },
+      checks: {
+        listForRef: vi.fn().mockResolvedValue({ data: { check_runs: [] } }),
+      },
+    });
+
+    const handler = new MergeHandler({ octokit, sleep: noopSleep });
+    const result = await handler.execute(batchInput);
+
+    expect(result.success).toBe(true);
+    // B(1 file) → C(2 files) → A(3 files)
+    expect(mergeOrder).toEqual([2, 3, 1]);
+  });
+
+  it('falls back to sequential merge when planMergeOrder API fails', async () => {
+    const octokit = createMockOctokit({
+      pulls: {
+        list: vi.fn().mockResolvedValue({
+          data: [makePR(42, ['fleet-merge-ready'])],
+        }),
+        get: vi.fn().mockResolvedValue({
+          data: { head: { sha: 'abc123' } },
+        }),
+        merge: vi.fn().mockResolvedValue({ data: {} }),
+        updateBranch: vi.fn().mockResolvedValue({ data: {} }),
+        // listFiles throws — planning phase fails
+        listFiles: vi.fn().mockRejectedValue(new Error('API rate limit')),
+      },
+      checks: {
+        listForRef: vi.fn().mockResolvedValue({ data: { check_runs: [] } }),
+      },
+    });
+
+    const handler = new MergeHandler({ octokit, sleep: noopSleep });
+    const result = await handler.execute(batchInput);
+
+    // Should still work via fallback sequential path
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.merged).toEqual([42]);
+    }
+  });
+
+  it('batch resolves conflict group when first PR in group cannot merge', async () => {
+    const conflictError = new Error('Conflict') as any;
+    conflictError.status = 422;
+
+    const octokit = createMockOctokit({
+      pulls: {
+        list: vi.fn().mockResolvedValue({
+          data: [
+            makePR(1, ['fleet-merge-ready']),
+            makePR(2, ['fleet-merge-ready']),
+          ],
+        }),
+        get: vi.fn().mockImplementation(({ pull_number, mediaType }: any) => {
+          if (mediaType?.format === 'diff') {
+            return { data: `diff for PR #${pull_number}` };
+          }
+          return { data: { head: { sha: 'abc' }, mergeable: false } };
+        }),
+        merge: vi.fn(),
+        update: vi.fn().mockResolvedValue({ data: {} }),
+        updateBranch: vi.fn().mockRejectedValue(conflictError),
+        listFiles: vi.fn().mockImplementation(({ pull_number }: any) => {
+          return { data: [{ filename: 'shared.py' }] };
+        }),
+      },
+      checks: {
+        listForRef: vi.fn().mockResolvedValue({ data: { check_runs: [] } }),
+      },
+      issues: {
+        createComment: vi.fn().mockResolvedValue({ data: {} }),
+      },
+    });
+
+    const events: any[] = [];
+    const handler = new MergeHandler({
+      octokit,
+      sleep: noopSleep,
+      emit: (e: any) => events.push(e),
+    });
+
+    // Mock the jules import for batch resolve
+    vi.doMock('@google/jules-sdk', () => ({
+      jules: {
+        session: vi.fn().mockResolvedValue({ id: 'batch-session-1' }),
+      },
+    }));
+
+    const result = await handler.execute(batchInput);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Both PRs should be in the skipped/redispatched lists
+      expect(result.data.merged).toHaveLength(0);
+      expect(result.data.skipped).toContain(1);
+      expect(result.data.skipped).toContain(2);
+    }
+
+    vi.doUnmock('@google/jules-sdk');
   });
 });

--- a/packages/fleet/src/__tests__/plan-merge-order.test.ts
+++ b/packages/fleet/src/__tests__/plan-merge-order.test.ts
@@ -1,0 +1,343 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildPRFileOwnership,
+  detectPROverlaps,
+  partitionPRs,
+  fetchPRFiles,
+  planMergeOrder,
+} from '../merge/ops/plan-merge-order.js';
+import type { PR } from '../shared/schemas/pr.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function makePR(number: number): PR {
+  return {
+    number,
+    headRef: `branch-${number}`,
+    headSha: `sha-${number}`,
+    body: `PR #${number} body`,
+  };
+}
+
+function createMockOctokit(
+  filesByPR: Record<number, string[]>,
+  shouldFail: number[] = [],
+) {
+  return {
+    rest: {
+      pulls: {
+        listFiles: vi.fn().mockImplementation(({ pull_number }: any) => {
+          if (shouldFail.includes(pull_number)) {
+            throw new Error('API error');
+          }
+          const files = filesByPR[pull_number] ?? [];
+          return Promise.resolve({
+            data: files.map((filename) => ({
+              filename,
+              status: 'modified',
+              additions: 1,
+              deletions: 0,
+              changes: 1,
+            })),
+          });
+        }),
+      },
+    },
+  } as any;
+}
+
+// ── buildPRFileOwnership ────────────────────────────────────────────
+
+describe('buildPRFileOwnership', () => {
+  it('builds ownership map from PR file data', () => {
+    const prFiles = new Map<number, string[]>([
+      [1, ['src/a.py', 'src/b.py']],
+      [2, ['src/b.py', 'src/c.py']],
+    ]);
+    const ownership = buildPRFileOwnership(prFiles);
+
+    expect(ownership.get('src/a.py')).toEqual([1]);
+    expect(ownership.get('src/b.py')).toEqual([1, 2]);
+    expect(ownership.get('src/c.py')).toEqual([2]);
+  });
+
+  it('handles empty file lists', () => {
+    const prFiles = new Map<number, string[]>([
+      [1, []],
+      [2, ['src/a.py']],
+    ]);
+    const ownership = buildPRFileOwnership(prFiles);
+    expect(ownership.size).toBe(1);
+    expect(ownership.get('src/a.py')).toEqual([2]);
+  });
+});
+
+// ── detectPROverlaps ────────────────────────────────────────────────
+
+describe('detectPROverlaps', () => {
+  it('extracts files owned by 2+ PRs', () => {
+    const ownership = new Map<string, number[]>([
+      ['src/a.py', [1]],
+      ['src/b.py', [1, 2]],
+      ['src/c.py', [2, 3]],
+    ]);
+    const overlaps = detectPROverlaps(ownership);
+    expect(overlaps).toHaveLength(2);
+    expect(overlaps).toContainEqual({ file: 'src/b.py', prs: [1, 2] });
+    expect(overlaps).toContainEqual({ file: 'src/c.py', prs: [2, 3] });
+  });
+
+  it('returns empty array when no overlaps', () => {
+    const ownership = new Map<string, number[]>([
+      ['src/a.py', [1]],
+      ['src/b.py', [2]],
+    ]);
+    expect(detectPROverlaps(ownership)).toEqual([]);
+  });
+});
+
+// ── partitionPRs ────────────────────────────────────────────────────
+
+describe('partitionPRs', () => {
+  it('returns empty plan for zero PRs', () => {
+    const plan = partitionPRs([], new Map());
+    expect(plan).toEqual({ independent: [], conflictGroups: [] });
+  });
+
+  it('classifies single PR as independent', () => {
+    const prs = [makePR(1)];
+    const prFiles = new Map([[1, ['src/a.py']]]);
+    const plan = partitionPRs(prs, prFiles);
+
+    expect(plan.independent).toHaveLength(1);
+    expect(plan.independent[0].number).toBe(1);
+    expect(plan.conflictGroups).toHaveLength(0);
+  });
+
+  it('classifies two PRs with no shared files as both independent', () => {
+    const prs = [makePR(1), makePR(2)];
+    const prFiles = new Map([
+      [1, ['src/a.py']],
+      [2, ['src/b.py']],
+    ]);
+    const plan = partitionPRs(prs, prFiles);
+
+    expect(plan.independent).toHaveLength(2);
+    expect(plan.conflictGroups).toHaveLength(0);
+  });
+
+  it('groups two PRs sharing one file into a conflict cluster', () => {
+    const prs = [makePR(1), makePR(2)];
+    const prFiles = new Map([
+      [1, ['src/a.py', 'src/shared.py']],
+      [2, ['src/b.py', 'src/shared.py']],
+    ]);
+    const plan = partitionPRs(prs, prFiles);
+
+    expect(plan.independent).toHaveLength(0);
+    expect(plan.conflictGroups).toHaveLength(1);
+    expect(plan.conflictGroups[0].prs.map((p) => p.number)).toEqual([1, 2]);
+    expect(plan.conflictGroups[0].sharedFiles).toEqual(['src/shared.py']);
+  });
+
+  it('detects transitive clustering: A↔B, B↔C → all in one cluster', () => {
+    const prs = [makePR(1), makePR(2), makePR(3)];
+    const prFiles = new Map([
+      [1, ['src/a.py', 'src/ab.py']],
+      [2, ['src/ab.py', 'src/bc.py']],
+      [3, ['src/bc.py', 'src/c.py']],
+    ]);
+    const plan = partitionPRs(prs, prFiles);
+
+    expect(plan.independent).toHaveLength(0);
+    expect(plan.conflictGroups).toHaveLength(1);
+    const cluster = plan.conflictGroups[0];
+    expect(cluster.prs.map((p) => p.number).sort()).toEqual([1, 2, 3]);
+    expect(cluster.sharedFiles.sort()).toEqual(['src/ab.py', 'src/bc.py']);
+  });
+
+  it('correctly partitions mix of independent and overlapping PRs', () => {
+    const prs = [makePR(1), makePR(2), makePR(3), makePR(4)];
+    const prFiles = new Map([
+      [1, ['.fleet/doc.md']], // isolated
+      [2, ['src/client.py', 'tests/test_client.py']], // overlaps with #3
+      [3, ['src/client.py', 'tests/test_models.py']], // overlaps with #2
+      [4, ['src/models.py']], // isolated
+    ]);
+    const plan = partitionPRs(prs, prFiles);
+
+    expect(plan.independent.map((p) => p.number).sort()).toEqual([1, 4]);
+    expect(plan.conflictGroups).toHaveLength(1);
+    expect(plan.conflictGroups[0].prs.map((p) => p.number).sort()).toEqual([
+      2, 3,
+    ]);
+  });
+
+  it('groups all PRs sharing the same file into one cluster', () => {
+    const prs = [makePR(1), makePR(2), makePR(3), makePR(4)];
+    const prFiles = new Map([
+      [1, ['src/client.py']],
+      [2, ['src/client.py']],
+      [3, ['src/client.py']],
+      [4, ['src/client.py']],
+    ]);
+    const plan = partitionPRs(prs, prFiles);
+
+    expect(plan.independent).toHaveLength(0);
+    expect(plan.conflictGroups).toHaveLength(1);
+    expect(plan.conflictGroups[0].prs).toHaveLength(4);
+  });
+
+  it('sorts independent PRs by ascending file count then PR number', () => {
+    const prs = [makePR(3), makePR(1), makePR(2)];
+    const prFiles = new Map([
+      [3, ['a.py', 'b.py', 'c.py']], // 3 files
+      [1, ['d.py', 'e.py']], // 2 files
+      [2, ['f.py']], // 1 file
+    ]);
+    const plan = partitionPRs(prs, prFiles);
+
+    expect(plan.independent.map((p) => p.number)).toEqual([2, 1, 3]);
+  });
+
+  it('sorts within conflict cluster by ascending overlap score then PR number', () => {
+    const prs = [makePR(3), makePR(1), makePR(2)];
+    // PR 1 overlaps on 2 files, PR 2 overlaps on 1 file, PR 3 overlaps on 1 file
+    const prFiles = new Map([
+      [1, ['src/shared1.py', 'src/shared2.py']], // overlaps in 2 files
+      [2, ['src/shared1.py', 'unique.py']], // overlaps in 1 file
+      [3, ['src/shared2.py', 'other.py']], // overlaps in 1 file
+    ]);
+    const plan = partitionPRs(prs, prFiles);
+
+    expect(plan.conflictGroups).toHaveLength(1);
+    // PR 2 and 3 have overlap score 1, PR 1 has overlap score 2
+    // PR 2 before 3 (tie-break by number), then PR 1
+    expect(plan.conflictGroups[0].prs.map((p) => p.number)).toEqual([2, 3, 1]);
+  });
+
+  it('handles PR with empty file list in a cluster (does not crash)', () => {
+    const prs = [makePR(1), makePR(2)];
+    const prFiles = new Map([
+      [1, []],
+      [2, ['src/a.py']],
+    ]);
+    const plan = partitionPRs(prs, prFiles);
+
+    // No overlap since PR 1 has no files
+    expect(plan.independent).toHaveLength(2);
+    expect(plan.conflictGroups).toHaveLength(0);
+  });
+
+  it('treats same file path with different statuses as overlap', () => {
+    // Even if one PR adds and another modifies the same file, it's an overlap
+    const prs = [makePR(1), makePR(2)];
+    const prFiles = new Map([
+      [1, ['src/new_file.py']],
+      [2, ['src/new_file.py']],
+    ]);
+    const plan = partitionPRs(prs, prFiles);
+
+    expect(plan.conflictGroups).toHaveLength(1);
+    expect(plan.conflictGroups[0].sharedFiles).toEqual(['src/new_file.py']);
+  });
+
+  it('different file paths are not overlaps even if basenames match', () => {
+    const prs = [makePR(1), makePR(2)];
+    const prFiles = new Map([
+      [1, ['tests/test_client.py']],
+      [2, ['src/test_client.py']],
+    ]);
+    const plan = partitionPRs(prs, prFiles);
+
+    expect(plan.independent).toHaveLength(2);
+    expect(plan.conflictGroups).toHaveLength(0);
+  });
+});
+
+// ── fetchPRFiles ────────────────────────────────────────────────────
+
+describe('fetchPRFiles', () => {
+  it('fetches changed files for each PR', async () => {
+    const octokit = createMockOctokit({
+      1: ['src/a.py', 'src/b.py'],
+      2: ['src/c.py'],
+    });
+    const prs = [makePR(1), makePR(2)];
+    const result = await fetchPRFiles(octokit, 'owner', 'repo', prs);
+
+    expect(result.get(1)).toEqual(['src/a.py', 'src/b.py']);
+    expect(result.get(2)).toEqual(['src/c.py']);
+  });
+
+  it('returns empty file list on API error (non-fatal)', async () => {
+    const octokit = createMockOctokit({ 1: ['src/a.py'] }, [2]);
+    const prs = [makePR(1), makePR(2)];
+    const result = await fetchPRFiles(octokit, 'owner', 'repo', prs);
+
+    expect(result.get(1)).toEqual(['src/a.py']);
+    expect(result.get(2)).toEqual([]); // failed gracefully
+  });
+
+  it('handles PRs with no changed files', async () => {
+    const octokit = createMockOctokit({ 1: [] });
+    const prs = [makePR(1)];
+    const result = await fetchPRFiles(octokit, 'owner', 'repo', prs);
+
+    expect(result.get(1)).toEqual([]);
+  });
+});
+
+// ── planMergeOrder (integration) ────────────────────────────────────
+
+describe('planMergeOrder', () => {
+  it('produces correct plan for the production scenario', async () => {
+    // Mirrors the actual jules-sdk-python merge run:
+    // #52: .fleet/insight_38.md  (isolated doc)
+    // #53: client.py, test_client.py  (overlaps with #54, #55, #57)
+    // #54: test_client.py, test_models.py  (overlaps with #53, #56)
+    // #55: client.py, test_client.py  (overlaps with #53, #54)
+    // #56: models.py, test_models.py  (overlaps with #54)
+    // #57: client.py  (overlaps with #53, #55)
+    const octokit = createMockOctokit({
+      52: ['.fleet/insight_38.md'],
+      53: ['src/jules/client.py', 'tests/test_client.py'],
+      54: ['tests/test_client.py', 'tests/test_models.py'],
+      55: ['src/jules/client.py', 'tests/test_client.py'],
+      56: ['src/jules/models.py', 'tests/test_models.py'],
+      57: ['src/jules/client.py'],
+    });
+
+    const prs = [makePR(52), makePR(53), makePR(54), makePR(55), makePR(56), makePR(57)];
+    const plan = await planMergeOrder(octokit, 'owner', 'repo', prs);
+
+    // #52 should be independent (isolated .fleet/ file)
+    expect(plan.independent.map((p) => p.number)).toEqual([52]);
+
+    // All others are connected through overlapping files
+    expect(plan.conflictGroups).toHaveLength(1);
+    const cluster = plan.conflictGroups[0];
+    expect(cluster.prs.map((p) => p.number).sort()).toEqual([53, 54, 55, 56, 57]);
+
+    // Shared files should include all overlapping files
+    expect(cluster.sharedFiles.sort()).toEqual([
+      'src/jules/client.py',
+      'tests/test_client.py',
+      'tests/test_models.py',
+    ]);
+  });
+});

--- a/packages/fleet/src/cli/merge.command.ts
+++ b/packages/fleet/src/cli/merge.command.ts
@@ -45,9 +45,9 @@ export default defineCommand({
       description: 'Use admin privileges to bypass branch protection',
       default: false,
     },
-    're-dispatch': {
+    'redispatch': {
       type: 'boolean',
-      description: 'Automatically re-dispatch tasks on merge conflict (requires JULES_API_KEY)',
+      description: 'Enable smart conflict resolution on merge conflict (requires JULES_API_KEY)',
       default: false,
     },
     owner: {
@@ -78,7 +78,7 @@ export default defineCommand({
       runId: args['run-id'] || undefined,
       baseBranch: args.base,
       admin: args.admin,
-      reDispatch: args['re-dispatch'],
+      redispatch: args['redispatch'],
       owner,
       repo,
     });

--- a/packages/fleet/src/init/templates/merge.ts
+++ b/packages/fleet/src/init/templates/merge.ts
@@ -44,8 +44,8 @@ on:
         description: 'Fleet run ID (required for fleet-run mode)'
         type: string
         default: ''
-      re_dispatch:
-        description: 'Auto re-dispatch on merge conflict'
+      redispatch:
+        description: 'Enable smart conflict resolution'
         type: boolean
         default: true
 
@@ -67,8 +67,8 @@ jobs:
           node-version: '22'
       - run: |
           REDISPATCH_FLAG=""
-          if [ "\${{ inputs.re_dispatch }}" = "true" ]; then
-            REDISPATCH_FLAG="--re-dispatch"
+          if [ "\${{ inputs.redispatch }}" = "true" ]; then
+            REDISPATCH_FLAG="--redispatch"
           fi
           npx @google/jules-fleet merge \\\\
             --mode \${{ inputs.mode || 'label' }} \\\\

--- a/packages/fleet/src/merge/handler.ts
+++ b/packages/fleet/src/merge/handler.ts
@@ -27,6 +27,8 @@ import { updateBranch } from './ops/update-branch.js';
 import { waitForCI } from './ops/wait-for-ci.js';
 import { squashMerge } from './ops/squash-merge.js';
 import { redispatch } from './ops/redispatch.js';
+import { planMergeOrder } from './ops/plan-merge-order.js';
+import { batchResolveConflicts } from './ops/resolve-conflicts.js';
 import { ConflictEscalationHandler } from './escalation/handler.js';
 
 export interface MergeHandlerDeps {
@@ -77,7 +79,115 @@ export class MergeHandler implements MergeSpec {
       const skipped: number[] = [];
       const redispatched: Array<{ oldPr: number; sessionId?: string }> = [];
 
-      // 2. Sequential merge loop
+      // 2. Plan merge order if batch mode is enabled
+      if (input.redispatch) {
+        try {
+          const plan = await planMergeOrder(
+            this.octokit,
+            input.owner,
+            input.repo,
+            prs,
+          );
+
+          this.emit({
+            type: 'merge:plan:computed',
+            independent: plan.independent.map((p) => p.number),
+            conflictGroups: plan.conflictGroups.map((g) =>
+              g.prs.map((p) => p.number),
+            ),
+          });
+
+          // 2a. Merge independent PRs first (no overlap between them)
+          for (const pr of plan.independent) {
+            const result = await this.mergeSinglePR(pr, input);
+            if (result.merged) {
+              merged.push(pr.number);
+            } else if (result.redispatched) {
+              redispatched.push({ oldPr: pr.number, sessionId: result.sessionId });
+              skipped.push(pr.number);
+            } else {
+              skipped.push(pr.number);
+            }
+            await this.sleep(5_000);
+          }
+
+          // 2b. Handle conflict groups with batch resolution
+          for (const group of plan.conflictGroups) {
+            // Try merging the first PR in the group (least overlapping)
+            const firstPR = group.prs[0];
+            const firstResult = await this.mergeSinglePR(firstPR, input);
+
+            if (firstResult.merged) {
+              merged.push(firstPR.number);
+              await this.sleep(5_000);
+
+              // Re-check remaining PRs in the group
+              const remaining = group.prs.slice(1);
+              for (const pr of remaining) {
+                const result = await this.mergeSinglePR(pr, input);
+                if (result.merged) {
+                  merged.push(pr.number);
+                } else {
+                  // If it conflicts, add to batch for resolution
+                  skipped.push(pr.number);
+                }
+                await this.sleep(5_000);
+              }
+            } else {
+              // First PR in group couldn't merge — batch resolve the whole group
+              const resolveResult = await batchResolveConflicts(
+                this.octokit,
+                {
+                  owner: input.owner,
+                  repo: input.repo,
+                  baseBranch: input.baseBranch,
+                  conflictingPRs: group.prs,
+                  sharedFiles: group.sharedFiles,
+                  recentlyMerged: merged,
+                },
+                this.emit,
+                async () => {
+                  const { jules } = await import('@google/jules-sdk');
+                  return jules;
+                },
+              );
+
+              if (resolveResult.success) {
+                for (const pr of group.prs) {
+                  redispatched.push({
+                    oldPr: pr.number,
+                    sessionId: resolveResult.sessionId,
+                  });
+                  skipped.push(pr.number);
+                }
+              } else {
+                // Fall back to per-PR redispatch
+                for (const pr of group.prs) {
+                  await redispatch(
+                    this.octokit,
+                    input.owner,
+                    input.repo,
+                    pr,
+                    input.baseBranch,
+                    input.pollTimeoutSeconds,
+                    this.emit,
+                    this.sleep,
+                  );
+                  redispatched.push({ oldPr: pr.number });
+                  skipped.push(pr.number);
+                }
+              }
+            }
+          }
+
+          this.emit({ type: 'merge:done', merged, skipped, redispatched });
+          return ok({ merged, skipped, redispatched });
+        } catch {
+          // Planning failed — fall through to sequential merge
+        }
+      }
+
+      // 3. Sequential merge loop (original behavior / fallback)
       for (const pr of prs) {
         let currentPr = pr;
         let retryCount = 0;
@@ -103,10 +213,10 @@ export class MergeHandler implements MergeSpec {
 
           if (!updateResult.ok && updateResult.conflict) {
             // If re-dispatch is disabled, fail immediately on conflict
-            if (!input.reDispatch) {
+            if (!input.redispatch) {
               return fail(
                 'CONFLICT_RETRIES_EXHAUSTED',
-                `Merge conflict detected for PR #${currentPr.number}. Use --re-dispatch to automatically retry.`,
+                `Merge conflict detected for PR #${currentPr.number}. Use --redispatch to automatically retry.`,
                 false,
                 `Review PR: https://github.com/${input.owner}/${input.repo}/pull/${currentPr.number}`,
               );
@@ -165,7 +275,7 @@ export class MergeHandler implements MergeSpec {
             // No CI checks — proceed
           } else if (ciResult === 'fail') {
             // Check if this is an exhausted conflict — escalate if re-dispatch is on
-            if (input.reDispatch) {
+            if (input.redispatch) {
               const escalation = new ConflictEscalationHandler(
                 this.octokit,
                 async () => {
@@ -250,6 +360,80 @@ export class MergeHandler implements MergeSpec {
   }
 
   // ── Private helpers ────────────────────────────────────────────────
+
+  /**
+   * Attempts to merge a single PR through the full pipeline:
+   * update branch → wait CI → squash merge.
+   * Returns a simple status for the caller to handle.
+   */
+  private async mergeSinglePR(
+    pr: PR,
+    input: MergeInput,
+  ): Promise<{
+    merged: boolean;
+    redispatched?: boolean;
+    sessionId?: string;
+  }> {
+    this.emit({
+      type: 'merge:pr:processing',
+      number: pr.number,
+      title: pr.body?.split('\n')[0] ?? `PR #${pr.number}`,
+    });
+
+    const updateResult = await updateBranch(
+      this.octokit,
+      input.owner,
+      input.repo,
+      pr.number,
+      this.emit,
+      this.sleep,
+    );
+
+    if (!updateResult.ok && updateResult.conflict) {
+      this.emit({ type: 'merge:conflict:detected', prNumber: pr.number });
+      return { merged: false };
+    }
+
+    if (!updateResult.ok && !updateResult.conflict) {
+      return { merged: false };
+    }
+
+    await this.sleep(5_000);
+
+    const ciResult = await waitForCI(
+      this.octokit,
+      input.owner,
+      input.repo,
+      pr.number,
+      input.maxCIWaitSeconds * 1000,
+      this.emit,
+      this.sleep,
+    );
+
+    if (ciResult === 'fail' || ciResult === 'timeout') {
+      this.emit({
+        type: 'merge:pr:skipped',
+        prNumber: pr.number,
+        reason: ciResult === 'fail' ? 'CI failure' : 'CI timeout',
+      });
+      return { merged: false };
+    }
+
+    this.emit({ type: 'merge:pr:merging', prNumber: pr.number });
+    const mergeResult = await squashMerge(
+      this.octokit,
+      input.owner,
+      input.repo,
+      pr.number,
+    );
+
+    if (!mergeResult.ok) {
+      return { merged: false };
+    }
+
+    this.emit({ type: 'merge:pr:merged', prNumber: pr.number });
+    return { merged: true };
+  }
 
   private async selectPRs(input: MergeInput): Promise<PR[]> {
     if (input.mode === 'fleet-run') {

--- a/packages/fleet/src/merge/ops/plan-merge-order.ts
+++ b/packages/fleet/src/merge/ops/plan-merge-order.ts
@@ -1,0 +1,208 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Octokit } from 'octokit';
+import type { PR } from '../../shared/schemas/pr.js';
+import { UnionFind } from '../../shared/union-find.js';
+
+// ── Types ───────────────────────────────────────────────────────────
+
+export interface ConflictGroup {
+  /** PRs in this conflict cluster, ordered by ascending overlap score */
+  prs: PR[];
+  /** Files shared between PRs in this cluster */
+  sharedFiles: string[];
+}
+
+export interface MergePlan {
+  /** PRs with no file overlap — safe to merge independently */
+  independent: PR[];
+  /** Groups of PRs that share files — will likely conflict when merged sequentially */
+  conflictGroups: ConflictGroup[];
+}
+
+// ── Pure Functions (independently testable) ─────────────────────────
+
+/**
+ * Build a map of file → PR numbers that touch it.
+ * Pure function — no side effects.
+ */
+export function buildPRFileOwnership(
+  prFiles: Map<number, string[]>,
+): Map<string, number[]> {
+  const ownership = new Map<string, number[]>();
+  for (const [prNumber, files] of prFiles) {
+    for (const file of files) {
+      if (!ownership.has(file)) {
+        ownership.set(file, []);
+      }
+      ownership.get(file)!.push(prNumber);
+    }
+  }
+  return ownership;
+}
+
+/**
+ * Extract files owned by 2+ PRs from the ownership map.
+ * Pure function — no side effects.
+ */
+export function detectPROverlaps(
+  ownership: Map<string, number[]>,
+): Array<{ file: string; prs: number[] }> {
+  const overlaps: Array<{ file: string; prs: number[] }> = [];
+  for (const [file, prs] of ownership) {
+    if (prs.length > 1) {
+      overlaps.push({ file, prs: [...prs].sort((a, b) => a - b) });
+    }
+  }
+  return overlaps;
+}
+
+/**
+ * Partition PRs into independent (no shared files) and conflict groups
+ * (connected via union-find through shared files).
+ * Pure function — no side effects.
+ */
+export function partitionPRs(
+  prs: PR[],
+  prFiles: Map<number, string[]>,
+): MergePlan {
+  if (prs.length === 0) {
+    return { independent: [], conflictGroups: [] };
+  }
+
+  const ownership = buildPRFileOwnership(prFiles);
+  const overlaps = detectPROverlaps(ownership);
+
+  if (overlaps.length === 0) {
+    // No overlaps — all PRs are independent
+    // Sort by ascending file count, then by PR number
+    const sorted = [...prs].sort((a, b) => {
+      const aFiles = prFiles.get(a.number)?.length ?? 0;
+      const bFiles = prFiles.get(b.number)?.length ?? 0;
+      return aFiles - bFiles || a.number - b.number;
+    });
+    return { independent: sorted, conflictGroups: [] };
+  }
+
+  // Build union-find to cluster PRs by shared files
+  const uf = new UnionFind<number>();
+  for (const pr of prs) {
+    uf.makeSet(pr.number);
+  }
+  for (const overlap of overlaps) {
+    for (let i = 1; i < overlap.prs.length; i++) {
+      uf.union(overlap.prs[0], overlap.prs[i]);
+    }
+  }
+
+  // Group PRs by cluster
+  const groups = uf.groups();
+  const prMap = new Map(prs.map((pr) => [pr.number, pr]));
+
+  const independent: PR[] = [];
+  const conflictGroups: ConflictGroup[] = [];
+
+  for (const group of groups) {
+    if (group.length === 1) {
+      const pr = prMap.get(group[0]);
+      if (pr) independent.push(pr);
+    } else {
+      const clusterPRSet = new Set(group);
+      const sharedFiles = overlaps
+        .filter((o) => o.prs.some((p) => clusterPRSet.has(p)))
+        .map((o) => o.file);
+
+      // Sort PRs within the cluster by ascending overlap score (fewest overlapping files first)
+      const clusterPRs = group
+        .map((num) => prMap.get(num)!)
+        .filter(Boolean)
+        .sort((a, b) => {
+          const aOverlapCount = overlaps.filter((o) =>
+            o.prs.includes(a.number),
+          ).length;
+          const bOverlapCount = overlaps.filter((o) =>
+            o.prs.includes(b.number),
+          ).length;
+          return aOverlapCount - bOverlapCount || a.number - b.number;
+        });
+
+      conflictGroups.push({
+        prs: clusterPRs,
+        sharedFiles: [...new Set(sharedFiles)].sort(),
+      });
+    }
+  }
+
+  // Sort independent PRs by ascending file count, then PR number
+  independent.sort((a, b) => {
+    const aFiles = prFiles.get(a.number)?.length ?? 0;
+    const bFiles = prFiles.get(b.number)?.length ?? 0;
+    return aFiles - bFiles || a.number - b.number;
+  });
+
+  return { independent, conflictGroups };
+}
+
+// ── API Integration ─────────────────────────────────────────────────
+
+/**
+ * Fetch changed files for each PR via the GitHub API.
+ * Returns a map of PR number → file paths.
+ * Non-fatal: returns empty file list on API error.
+ */
+export async function fetchPRFiles(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prs: PR[],
+): Promise<Map<number, string[]>> {
+  const prFiles = new Map<number, string[]>();
+
+  await Promise.all(
+    prs.map(async (pr) => {
+      try {
+        const { data: files } = await octokit.rest.pulls.listFiles({
+          owner,
+          repo,
+          pull_number: pr.number,
+          per_page: 100,
+        });
+        prFiles.set(
+          pr.number,
+          files.map((f) => f.filename),
+        );
+      } catch {
+        // Non-fatal — treat as no files (won't block merge)
+        prFiles.set(pr.number, []);
+      }
+    }),
+  );
+
+  return prFiles;
+}
+
+/**
+ * Plans the merge order by fetching file data and partitioning PRs.
+ * This is the main entry point called by the merge handler.
+ */
+export async function planMergeOrder(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prs: PR[],
+): Promise<MergePlan> {
+  const prFiles = await fetchPRFiles(octokit, owner, repo, prs);
+  return partitionPRs(prs, prFiles);
+}

--- a/packages/fleet/src/merge/ops/resolve-conflicts.ts
+++ b/packages/fleet/src/merge/ops/resolve-conflicts.ts
@@ -1,0 +1,251 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Octokit } from 'octokit';
+import type { PR } from '../../shared/schemas/pr.js';
+import type { FleetEmitter } from '../../shared/events.js';
+
+// ── Types ───────────────────────────────────────────────────────────
+
+export interface BatchResolveInput {
+  owner: string;
+  repo: string;
+  baseBranch: string;
+  /** PRs that conflict with each other / with the current base */
+  conflictingPRs: PR[];
+  /** Files shared between the conflicting PRs */
+  sharedFiles: string[];
+  /** PRs that were recently merged (provides context) */
+  recentlyMerged: number[];
+}
+
+export interface BatchResolveSuccess {
+  success: true;
+  sessionId: string;
+  resolvedPRs: number[];
+}
+
+export interface BatchResolveFailure {
+  success: false;
+  error: string;
+}
+
+export type BatchResolveResult = BatchResolveSuccess | BatchResolveFailure;
+
+// ── Constants ───────────────────────────────────────────────────────
+
+/** Max characters per PR diff to avoid prompt bloat */
+const MAX_DIFF_LENGTH = 8_000;
+
+// ── Core ────────────────────────────────────────────────────────────
+
+/**
+ * Resolves a batch of conflicting PRs by dispatching a single Jules session
+ * with all their diffs and context. Does NOT close the original PRs.
+ */
+export async function batchResolveConflicts(
+  octokit: Octokit,
+  input: BatchResolveInput,
+  emit: FleetEmitter,
+  julesProvider: () => Promise<typeof import('@google/jules-sdk')['jules']>,
+): Promise<BatchResolveResult> {
+  const { owner, repo, baseBranch, conflictingPRs, sharedFiles, recentlyMerged } = input;
+
+  emit({
+    type: 'merge:batch-resolve:start',
+    prNumbers: conflictingPRs.map((p) => p.number),
+    sharedFiles,
+  });
+
+  // 1. Fetch diffs for all conflicting PRs (non-fatal per-PR)
+  const diffs = await fetchAllDiffs(octokit, owner, repo, conflictingPRs);
+
+  // 2. Build the combined prompt
+  const prompt = buildBatchPrompt(input, diffs);
+
+  // 3. Dispatch a single Jules session
+  let sessionId: string;
+  try {
+    const jules = await julesProvider();
+    const session = await jules.session({
+      prompt,
+      source: {
+        github: `${owner}/${repo}`,
+        baseBranch,
+      },
+      requireApproval: false,
+      autoPr: true,
+    });
+    sessionId = session.id;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    emit({
+      type: 'error',
+      code: 'BATCH_RESOLVE_FAILED',
+      message: `Batch resolve dispatch failed: ${message}`,
+    });
+    return { success: false, error: message };
+  }
+
+  // 4. Comment on each original PR (non-fatal)
+  await commentOnPRs(octokit, owner, repo, conflictingPRs, sessionId);
+
+  emit({
+    type: 'merge:batch-resolve:done',
+    sessionId,
+    prNumbers: conflictingPRs.map((p) => p.number),
+  });
+
+  return {
+    success: true,
+    sessionId,
+    resolvedPRs: conflictingPRs.map((p) => p.number),
+  };
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Fetches the diff for each PR. Returns a map of PR number → diff string.
+ * Non-fatal: returns empty string for PRs where the API call fails.
+ */
+async function fetchAllDiffs(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prs: PR[],
+): Promise<Map<number, string>> {
+  const diffs = new Map<number, string>();
+
+  await Promise.all(
+    prs.map(async (pr) => {
+      try {
+        const { data: diff } = await octokit.rest.pulls.get({
+          owner,
+          repo,
+          pull_number: pr.number,
+          mediaType: { format: 'diff' },
+        });
+        const diffStr = diff as unknown as string;
+        diffs.set(
+          pr.number,
+          diffStr.length > MAX_DIFF_LENGTH
+            ? diffStr.slice(0, MAX_DIFF_LENGTH) + '\n... (diff truncated)'
+            : diffStr,
+        );
+      } catch {
+        diffs.set(pr.number, '');
+      }
+    }),
+  );
+
+  return diffs;
+}
+
+/**
+ * Builds a comprehensive prompt for batch conflict resolution.
+ * Exported for testing.
+ */
+export function buildBatchPrompt(
+  input: BatchResolveInput,
+  diffs: Map<number, string>,
+): string {
+  const { conflictingPRs, sharedFiles, recentlyMerged, owner, repo } = input;
+  const lines: string[] = [
+    '⚠️ BATCH CONFLICT RESOLUTION',
+    '',
+    `The following ${conflictingPRs.length} PRs in ${owner}/${repo} conflict with the current base branch after recent merges.`,
+    'Resolve all of them together in a single PR.',
+    '',
+  ];
+
+  // Shared files summary
+  lines.push('## Conflicting Files');
+  lines.push('These files are touched by multiple PRs and likely contain conflicts:');
+  for (const file of sharedFiles) {
+    lines.push(`- \`${file}\``);
+  }
+  lines.push('');
+
+  // Recently merged context
+  if (recentlyMerged.length > 0) {
+    lines.push('## Recently Merged PRs');
+    lines.push('These PRs were merged just before, and their changes are now in the base branch:');
+    for (const num of recentlyMerged) {
+      lines.push(`- PR #${num}`);
+    }
+    lines.push('');
+  }
+
+  // Per-PR details
+  lines.push('## PRs to Resolve');
+  for (const pr of conflictingPRs) {
+    lines.push(`### PR #${pr.number}`);
+    if (pr.body) {
+      lines.push(pr.body.split('\n')[0]); // First line of body as summary
+    }
+    const diff = diffs.get(pr.number);
+    if (diff) {
+      lines.push('');
+      lines.push('```diff');
+      lines.push(diff);
+      lines.push('```');
+    }
+    lines.push('');
+  }
+
+  lines.push('## Instructions');
+  lines.push('Create ONE PR that incorporates ALL changes from the listed PRs above,');
+  lines.push('resolved against the current state of the base branch.');
+  lines.push('Do NOT duplicate work that already exists in the base branch from recently merged PRs.');
+
+  return lines.join('\n');
+}
+
+/**
+ * Adds a comment to each original PR explaining the batch resolution.
+ * Non-fatal — does not throw on failure.
+ */
+async function commentOnPRs(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prs: PR[],
+  sessionId: string,
+): Promise<void> {
+  const prList = prs.map((p) => `#${p.number}`).join(', ');
+  const body = [
+    '🔄 **Batch conflict resolution in progress**',
+    '',
+    `This PR is part of a batch being resolved together: ${prList}`,
+    `A Jules session has been dispatched to create a combined PR that resolves all conflicts.`,
+    '',
+    `Session ID: \`${sessionId}\``,
+  ].join('\n');
+
+  await Promise.all(
+    prs.map(async (pr) => {
+      try {
+        await octokit.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: pr.number,
+          body,
+        });
+      } catch {
+        // Non-fatal — comment failure shouldn't block the resolution
+      }
+    }),
+  );
+}

--- a/packages/fleet/src/merge/spec.ts
+++ b/packages/fleet/src/merge/spec.ts
@@ -31,11 +31,11 @@ export const MergeInputSchema = z
     admin: z.boolean().default(false),
     /** Max seconds to wait for CI per PR */
     maxCIWaitSeconds: z.number().positive().default(600),
-    /** Max re-dispatch attempts per PR on conflict */
+    /** Max retries per PR on conflict */
     maxRetries: z.number().nonnegative().default(2),
-    /** Enable automatic re-dispatch on merge conflict (requires JULES_API_KEY) */
-    reDispatch: z.boolean().default(false),
-    /** Max seconds to wait for re-dispatched PR to appear */
+    /** Enable smart conflict resolution on merge conflict (requires JULES_API_KEY) */
+    redispatch: z.boolean().default(false),
+    /** Max seconds to wait for redispatched PR to appear */
     pollTimeoutSeconds: z.number().positive().default(900),
     /** Repository owner */
     owner: z.string().min(1),

--- a/packages/fleet/src/shared/events/merge.ts
+++ b/packages/fleet/src/shared/events/merge.ts
@@ -32,6 +32,9 @@ export type MergeEvent =
   | { type: 'merge:conflict:escalated'; prNumber: number; sessionId: string; failureCount: number }
   | { type: 'merge:redispatch:start'; oldPr: number }
   | { type: 'merge:redispatch:done'; oldPr: number; sessionId: string }
+  | { type: 'merge:plan:computed'; independent: number[]; conflictGroups: number[][] }
+  | { type: 'merge:batch-resolve:start'; prNumbers: number[]; sharedFiles: string[] }
+  | { type: 'merge:batch-resolve:done'; sessionId: string; prNumbers: number[] }
   | {
       type: 'merge:done';
       merged: number[];


### PR DESCRIPTION
- Add plan-merge-order.ts: fetches PR files, partitions into independent/conflict groups via union-find
- Add resolve-conflicts.ts: dispatches one Jules session per conflict group instead of N separate close+redispatch cycles
- Collapse reDispatch + batchRedispatch into single --redispatch flag
- Handler: plan merge order → merge independents first → batch resolve conflict groups → sequential fallback
- 3 new event types: merge:plan:computed, merge:batch-resolve:start, merge:batch-resolve:done
- 34 new tests across plan-merge-order, batch-resolve, and merge-handler