### PR TITLE
fix(fleet): dispatch cron milestone discovery and formatting fixes

### DIFF
--- a/packages/fleet/package.json
+++ b/packages/fleet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/jules-fleet",
-  "version": "0.0.1-experimental.25",
+  "version": "0.0.1-experimental.26",
   "type": "module",
   "description": "Fleet orchestration tools for Jules — analyze, dispatch, merge, init, configure",
   "repository": {

--- a/packages/fleet/src/__tests__/dispatch-formatting.test.ts
+++ b/packages/fleet/src/__tests__/dispatch-formatting.test.ts
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import { sessionUrl } from '../shared/ui/session-url.js';
+
+describe('sessionUrl', () => {
+  it('uses /session/ (singular) in the URL', () => {
+    const url = sessionUrl('12345');
+    expect(url).toBe('https://jules.google.com/session/12345');
+    expect(url).not.toContain('/sessions/');
+  });
+});
+
+describe('dispatch comment session regex', () => {
+  // The regex from status.ts: /Session:\s*\[?`([^`]+)`\]?/
+  const regex = /Session:\s*\[?`([^`]+)`\]?/;
+
+  it('parses old format: Session: `id`', () => {
+    const body = '🤖 **Fleet Dispatch Event**\nSession: `abc123`\nTimestamp: 2026-01-01';
+    const match = body.match(regex);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe('abc123');
+  });
+
+  it('parses new format: Session: [`id`](url)', () => {
+    const body = '🤖 **Fleet Dispatch Event**\nSession: [`abc123`](https://jules.google.com/session/abc123)\nTimestamp: Mar 3, 2026';
+    const match = body.match(regex);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe('abc123');
+  });
+
+  it('handles numeric session IDs', () => {
+    const body = 'Session: [`17338656567244366276`](https://jules.google.com/session/17338656567244366276)';
+    const match = body.match(regex);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe('17338656567244366276');
+  });
+});

--- a/packages/fleet/src/__tests__/dispatch-template.test.ts
+++ b/packages/fleet/src/__tests__/dispatch-template.test.ts
@@ -1,0 +1,101 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import { buildDispatchTemplate } from '../init/templates/dispatch.js';
+import * as yaml from 'yaml';
+
+describe('buildDispatchTemplate', () => {
+  const template = buildDispatchTemplate(360);
+
+  it('has a .yml repoPath under .github/workflows/', () => {
+    expect(template.repoPath).toMatch(
+      /^\.github\/workflows\/.*\.yml$/,
+    );
+  });
+
+  it('content is valid YAML', () => {
+    expect(() => yaml.parse(template.content)).not.toThrow();
+  });
+
+  it('references jules-fleet dispatch command', () => {
+    expect(template.content).toContain('jules-fleet dispatch');
+    expect(template.content).toContain('--package=@google/jules-fleet');
+  });
+
+  it('has two jobs: discover and dispatch', () => {
+    const parsed = yaml.parse(template.content);
+    expect(parsed.jobs.discover).toBeDefined();
+    expect(parsed.jobs.dispatch).toBeDefined();
+  });
+
+  it('discover job outputs milestones', () => {
+    const parsed = yaml.parse(template.content);
+    expect(parsed.jobs.discover.outputs.milestones).toBeDefined();
+  });
+
+  it('dispatch job uses matrix from discover output', () => {
+    const parsed = yaml.parse(template.content);
+    const dispatch = parsed.jobs.dispatch;
+    expect(dispatch.needs).toBe('discover');
+    expect(dispatch.strategy.matrix.milestone).toContain('fromJSON');
+    expect(dispatch.strategy.matrix.milestone).toContain('needs.discover.outputs.milestones');
+  });
+
+  it('milestone input is optional (not required)', () => {
+    const parsed = yaml.parse(template.content);
+    const milestone = parsed.on.workflow_dispatch.inputs.milestone;
+    expect(milestone.required).toBe(false);
+  });
+
+  it('discover step branches on INPUT_MILESTONE', () => {
+    const parsed = yaml.parse(template.content);
+    const listStep = parsed.jobs.discover.steps.find(
+      (s: { id?: string }) => s.id === 'list',
+    );
+    expect(listStep).toBeDefined();
+    expect(listStep.run).toContain('if [ -n "$INPUT_MILESTONE" ]');
+    expect(listStep.run).toContain('gh api');
+  });
+
+  it('dispatch job has correct permissions', () => {
+    const parsed = yaml.parse(template.content);
+    const perms = parsed.jobs.dispatch.permissions;
+    expect(perms.contents).toBe('read');
+    expect(perms.issues).toBe('write');
+  });
+
+  it('uses the provided cron interval', () => {
+    const t60 = buildDispatchTemplate(60);
+    const parsed60 = yaml.parse(t60.content);
+    expect(parsed60.on.schedule[0].cron).toBeDefined();
+
+    const t360 = buildDispatchTemplate(360);
+    const parsed360 = yaml.parse(t360.content);
+    expect(parsed360.on.schedule[0].cron).toBeDefined();
+
+    // Different intervals should produce different cron expressions
+    expect(parsed60.on.schedule[0].cron).not.toBe(parsed360.on.schedule[0].cron);
+  });
+
+  it('passes --milestone with matrix value', () => {
+    const parsed = yaml.parse(template.content);
+    const runStep = parsed.jobs.dispatch.steps.find(
+      (s: { run?: string }) => s.run?.includes('jules-fleet'),
+    );
+    expect(runStep).toBeDefined();
+    expect(runStep.run).toContain('--milestone');
+    expect(runStep.run).toContain('matrix.milestone');
+  });
+});

--- a/packages/fleet/src/dispatch/events.ts
+++ b/packages/fleet/src/dispatch/events.ts
@@ -33,10 +33,16 @@ export async function recordDispatch(
   sessionId: string,
 ): Promise<DispatchRecord> {
   const timestamp = new Date().toISOString();
+  const readableTime = new Date().toLocaleString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric',
+    hour: 'numeric', minute: '2-digit',
+    timeZone: 'UTC', timeZoneName: 'short',
+  });
+  const sessionLink = `https://jules.google.com/session/${sessionId}`;
   const body = [
     `🤖 **Fleet Dispatch Event**`,
-    `Session: \`${sessionId}\``,
-    `Timestamp: ${timestamp}`,
+    `Session: [\`${sessionId}\`](${sessionLink})`,
+    `Timestamp: ${readableTime}`,
   ].join('\n');
 
   const { data: comment } = await octokit.rest.issues.createComment({

--- a/packages/fleet/src/dispatch/status.ts
+++ b/packages/fleet/src/dispatch/status.ts
@@ -76,7 +76,7 @@ export async function getDispatchStatus(
 
     let dispatchEvent: DispatchEvent | null = null;
     if (dispatchComment?.body) {
-      const sessionMatch = dispatchComment.body.match(/Session:\s*`([^`]+)`/);
+      const sessionMatch = dispatchComment.body.match(/Session:\s*\[?`([^`]+)`\]?/);
       dispatchEvent = {
         sessionId: sessionMatch?.[1] ?? 'unknown',
         timestamp: dispatchComment.created_at,

--- a/packages/fleet/src/init/templates/dispatch.ts
+++ b/packages/fleet/src/init/templates/dispatch.ts
@@ -31,17 +31,39 @@ on:
   workflow_dispatch:
     inputs:
       milestone:
-        description: 'Milestone ID to dispatch'
+        description: 'Milestone ID to dispatch (leave empty to dispatch all)'
         type: string
-        required: true
+        required: false
 
 concurrency:
   group: fleet-dispatch
   cancel-in-progress: false
 
 jobs:
-  dispatch:
+  discover:
     runs-on: ubuntu-latest
+    outputs:
+      milestones: \${{ steps.list.outputs.milestones }}
+    steps:
+      - name: Resolve milestones
+        id: list
+        env:
+          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+          INPUT_MILESTONE: \${{ inputs.milestone }}
+        run: |
+          if [ -n "$INPUT_MILESTONE" ]; then
+            echo "milestones=[\\"$INPUT_MILESTONE\\"]" >> "$GITHUB_OUTPUT"
+          else
+            milestones=$(gh api repos/\${{ github.repository }}/milestones --jq '[.[].number | tostring]')
+            echo "milestones=$milestones" >> "$GITHUB_OUTPUT"
+          fi
+
+  dispatch:
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        milestone: \${{ fromJSON(needs.discover.outputs.milestones) }}
     permissions:
       contents: read
       issues: write
@@ -50,7 +72,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-      - run: npx -y --package=@google/jules-fleet jules-fleet dispatch --milestone \${{ inputs.milestone }}
+      - run: npx -y --package=@google/jules-fleet jules-fleet dispatch --milestone \${{ matrix.milestone }}
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
           JULES_API_KEY: \${{ secrets.JULES_API_KEY }}

--- a/packages/fleet/src/merge/conflict-resolution/handler.ts
+++ b/packages/fleet/src/merge/conflict-resolution/handler.ts
@@ -211,7 +211,7 @@ export class ConflictResolutionHandler implements ConflictResolutionSpec {
       '',
       `**Attempt:** ${attempt}/${maxAttempts}`,
       `**Conflicting files:** ${fileList}`,
-      `**Timestamp:** ${new Date().toISOString()}`,
+      `**Timestamp:** ${new Date().toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit', timeZone: 'UTC', timeZoneName: 'short' })}`,
       '',
       attempt >= maxAttempts
         ? '⛔ Max notifications reached. Next conflict will trigger redispatch.'

--- a/packages/fleet/src/merge/ops/resolve-conflicts.ts
+++ b/packages/fleet/src/merge/ops/resolve-conflicts.ts
@@ -270,7 +270,7 @@ async function commentOnPRs(
   sessionId: string,
 ): Promise<void> {
   const prList = prs.map((p) => `#${p.number}`).join(', ');
-  const sessionLink = `https://jules.google.com/sessions/${sessionId}`;
+  const sessionLink = `https://jules.google.com/session/${sessionId}`;
   const body = [
     '🔄 **Batch conflict resolution in progress**',
     '',

--- a/packages/fleet/src/shared/ui/session-url.ts
+++ b/packages/fleet/src/shared/ui/session-url.ts
@@ -18,7 +18,7 @@ const JULES_BASE_URL = 'https://jules.google.com';
  * Build a Jules session URL from a session ID.
  */
 export function sessionUrl(sessionId: string): string {
-  return `${JULES_BASE_URL}/sessions/${sessionId}`;
+  return `${JULES_BASE_URL}/session/${sessionId}`;
 }
 
 /**


### PR DESCRIPTION
- Dispatch template now uses two-job pattern: discover (lists milestones via gh api) → dispatch (matrix over discovered milestones)
- Fix session URL: /sessions/ → /session/ (singular)
- Dispatch comment: session ID as clickable link, human-readable timestamp
- Status regex: backward-compatible with both old and new comment formats
- Add dispatch-template and dispatch-formatting tests (15 new tests)
- Bump fleet to 0.0.1-experimental.26