### PR TITLE
fix(fleet): auto-discover milestones when --milestone is omitted

### DIFF
--- a/packages/fleet/package.json
+++ b/packages/fleet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/jules-fleet",
-  "version": "0.0.1-experimental.26",
+  "version": "0.0.1-experimental.27",
   "type": "module",
   "description": "Fleet orchestration tools for Jules — analyze, dispatch, merge, init, configure",
   "repository": {

--- a/packages/fleet/src/cli/dispatch.command.ts
+++ b/packages/fleet/src/cli/dispatch.command.ts
@@ -30,8 +30,8 @@ export default defineCommand({
   args: {
     milestone: {
       type: 'string',
-      description: 'Milestone ID to scope dispatch',
-      required: true,
+      description: 'Milestone ID to scope dispatch (omit to dispatch all)',
+      required: false,
     },
     owner: {
       type: 'string',
@@ -54,14 +54,26 @@ export default defineCommand({
       repo = repo || repoInfo.repo;
     }
 
-    renderer.start(`Fleet Dispatch — Milestone ${args.milestone}`);
+    const octokit = createFleetOctokit();
 
-    const input = DispatchInputSchema.parse({
-      milestone: args.milestone,
-      owner,
-      repo,
-      baseBranch: process.env.FLEET_BASE_BRANCH || 'main',
-    });
+    // Resolve milestone(s): specific one or auto-discover all
+    let milestones: string[];
+    if (args.milestone) {
+      milestones = [args.milestone];
+    } else {
+      renderer.start('Fleet Dispatch — Discovering milestones');
+      const { data } = await octokit.rest.issues.listMilestones({
+        owner: owner!,
+        repo: repo!,
+        state: 'open',
+      });
+      milestones = data.map((m) => String(m.number));
+      if (milestones.length === 0) {
+        renderer.end('No open milestones found — nothing to dispatch.');
+        return;
+      }
+      renderer.start(`Fleet Dispatch — ${milestones.length} milestone(s): ${milestones.join(', ')}`);
+    }
 
     const dispatcher: SessionDispatcher = {
       async dispatch(options) {
@@ -74,17 +86,34 @@ export default defineCommand({
       },
     };
 
-    const octokit = createFleetOctokit();
     const emit = createEmitter(renderer);
     const handler = new DispatchHandler({ octokit, dispatcher, emit });
-    const result = await handler.execute(input);
 
-    if (!result.success) {
-      renderer.error(result.error.message);
-      process.exit(1);
+    let totalDispatched = 0;
+    let totalSkipped = 0;
+
+    for (const milestone of milestones) {
+      renderer.start(`Fleet Dispatch — Milestone ${milestone}`);
+
+      const input = DispatchInputSchema.parse({
+        milestone,
+        owner,
+        repo,
+        baseBranch: process.env.FLEET_BASE_BRANCH || 'main',
+      });
+
+      const result = await handler.execute(input);
+
+      if (!result.success) {
+        renderer.error(`Milestone ${milestone}: ${result.error.message}`);
+        continue;
+      }
+
+      totalDispatched += result.data.dispatched.length;
+      totalSkipped += result.data.skipped;
     }
 
-    const { dispatched, skipped } = result.data;
-    renderer.end(`${dispatched.length} dispatched, ${skipped} skipped.`);
+    renderer.end(`${totalDispatched} dispatched, ${totalSkipped} skipped across ${milestones.length} milestone(s).`);
   },
 });
+

--- a/packages/fleet/src/dispatch/handler.ts
+++ b/packages/fleet/src/dispatch/handler.ts
@@ -48,7 +48,7 @@ export class DispatchHandler implements DispatchSpec {
 
   async execute(input: DispatchInput): Promise<DispatchResult> {
     try {
-      this.emit({ type: 'dispatch:start', milestone: input.milestone });
+      this.emit({ type: 'dispatch:start', milestone: input.milestone ?? 'all' });
       this.emit({ type: 'dispatch:scanning' });
 
       // Load verification commands from goal files

--- a/packages/fleet/src/dispatch/spec.ts
+++ b/packages/fleet/src/dispatch/spec.ts
@@ -17,8 +17,8 @@ import { z } from 'zod';
 // ── INPUT ───────────────────────────────────────────────────────────
 
 export const DispatchInputSchema = z.object({
-  /** Milestone ID to scope dispatch */
-  milestone: z.string().min(1),
+  /** Milestone ID to scope dispatch (omit to dispatch all milestones) */
+  milestone: z.string().min(1).optional(),
   /** Repository owner */
   owner: z.string().min(1),
   /** Repository name */


### PR DESCRIPTION
- Make --milestone optional in dispatch CLI and spec
- When omitted (e.g. cron trigger), list open milestones from GitHub and dispatch each sequentially
- Fixes cron dispatch failing with Zod validation error on empty milestone
- Bump to 0.0.1-experimental.27