### PR TITLE
fix: add --prefix /tmp/fleet to fleet workflows for monorepo isolation

### DIFF
--- a/.github/workflows/fleet-dispatch.yml
+++ b/.github/workflows/fleet-dispatch.yml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       milestone:
-        description: 'Milestone ID to dispatch'
+        description: 'Milestone ID to dispatch (leave empty to dispatch all)'
         type: string
-        required: true
+        required: false
 
 concurrency:
   group: fleet-dispatch
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-      - run: npx -y --package=@google/jules-fleet jules-fleet dispatch --milestone ${{ inputs.milestone }}
+      - run: npx -y --prefix /tmp/fleet --package=@google/jules-fleet jules-fleet dispatch --milestone ${{ inputs.milestone }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JULES_API_KEY: ${{ secrets.JULES_API_KEY }}

--- a/.github/workflows/fleet-merge.yml
+++ b/.github/workflows/fleet-merge.yml
@@ -48,7 +48,7 @@ jobs:
           if [ "${{ inputs.redispatch }}" = "false" ]; then
             REDISPATCH_FLAG=""
           fi
-          npx -y --package=@google/jules-fleet jules-fleet merge --mode ${{ inputs.mode || 'label' }} --run-id "${{ inputs.fleet_run_id }}" $REDISPATCH_FLAG
+          npx -y --prefix /tmp/fleet --package=@google/jules-fleet jules-fleet merge --mode ${{ inputs.mode || 'label' }} --run-id "${{ inputs.fleet_run_id }}" $REDISPATCH_FLAG
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JULES_API_KEY: ${{ secrets.JULES_API_KEY }}


### PR DESCRIPTION
npx resolves to the local workspace which lacks dist/, causing 'jules-fleet: not found'. Using --prefix isolates from workspaces. Also makes dispatch milestone optional (v27 auto-discovers).