### PR TITLE
fix: use explicit install+binary path for fleet workflows

### DIFF
--- a/.github/workflows/fleet-dispatch.yml
+++ b/.github/workflows/fleet-dispatch.yml
@@ -28,7 +28,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-      - run: npx -y --prefix /tmp/fleet --package=@google/jules-fleet jules-fleet dispatch --milestone ${{ inputs.milestone }}
+      - run: |
+          npm install --prefix /tmp/fleet @google/jules-fleet
+          /tmp/fleet/node_modules/.bin/jules-fleet dispatch --milestone ${{ inputs.milestone }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JULES_API_KEY: ${{ secrets.JULES_API_KEY }}

--- a/.github/workflows/fleet-merge.yml
+++ b/.github/workflows/fleet-merge.yml
@@ -48,7 +48,8 @@ jobs:
           if [ "${{ inputs.redispatch }}" = "false" ]; then
             REDISPATCH_FLAG=""
           fi
-          npx -y --prefix /tmp/fleet --package=@google/jules-fleet jules-fleet merge --mode ${{ inputs.mode || 'label' }} --run-id "${{ inputs.fleet_run_id }}" $REDISPATCH_FLAG
+          npm install --prefix /tmp/fleet @google/jules-fleet
+          /tmp/fleet/node_modules/.bin/jules-fleet merge --mode ${{ inputs.mode || 'label' }} --run-id "${{ inputs.fleet_run_id }}" $REDISPATCH_FLAG
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JULES_API_KEY: ${{ secrets.JULES_API_KEY }}


### PR DESCRIPTION
npx --prefix still resolves binaries from workspace. Use explicit npm install to /tmp/fleet then call binary from node_modules/.bin/ to fully isolate from monorepo workspace resolution.