### PR TITLE
fix: use Fleet App token for merge commits (CLA compliance)

### DIFF
--- a/.github/workflows/fleet-merge.yml
+++ b/.github/workflows/fleet-merge.yml
@@ -43,6 +43,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+      - name: Generate Fleet App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
       - run: |
           REDISPATCH_FLAG="--redispatch"
           if [ "${{ inputs.redispatch }}" = "false" ]; then
@@ -51,7 +57,7 @@ jobs:
           npm install --prefix /tmp/fleet @google/jules-fleet
           /tmp/fleet/node_modules/.bin/jules-fleet merge --mode ${{ inputs.mode || 'label' }} --run-id "${{ inputs.fleet_run_id }}" $REDISPATCH_FLAG
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
           GITHUB_APP_ID: ${{ secrets.FLEET_APP_ID }}
           GITHUB_APP_PRIVATE_KEY_BASE64: ${{ secrets.FLEET_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Generate an installation token from the Fleet GitHub App using actions/create-github-app-token, then pass it as GITHUB_TOKEN. This attributes merge/update-branch commits to the Fleet app bot instead of github-actions[bot], satisfying the CLA check.