### PR TITLE
fix: Fleet App token + workspace isolation + explicit secret names

### DIFF
--- a/.github/workflows/fleet-analyze.yml
+++ b/.github/workflows/fleet-analyze.yml
@@ -32,10 +32,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-      - run: npx -y --package=@google/jules-fleet jules-fleet analyze --goal "${{ inputs.goal }}" --milestone "${{ inputs.milestone }}"
+      - name: Generate Fleet App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+      - run: |
+          npm install --prefix /tmp/fleet @google/jules-fleet
+          /tmp/fleet/node_modules/.bin/jules-fleet analyze --goal "${{ inputs.goal }}" --milestone "${{ inputs.milestone }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
           GITHUB_APP_ID: ${{ secrets.FLEET_APP_ID }}
-          GITHUB_APP_PRIVATE_KEY_BASE64: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          GITHUB_APP_PRIVATE_KEY_BASE64: ${{ secrets.FLEET_APP_PRIVATE_KEY_BASE64 }}
           GITHUB_APP_INSTALLATION_ID: ${{ secrets.FLEET_APP_INSTALLATION_ID }}

--- a/.github/workflows/fleet-dispatch.yml
+++ b/.github/workflows/fleet-dispatch.yml
@@ -28,12 +28,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+      - name: Generate Fleet App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
       - run: |
           npm install --prefix /tmp/fleet @google/jules-fleet
           /tmp/fleet/node_modules/.bin/jules-fleet dispatch --milestone ${{ inputs.milestone }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
           GITHUB_APP_ID: ${{ secrets.FLEET_APP_ID }}
-          GITHUB_APP_PRIVATE_KEY_BASE64: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          GITHUB_APP_PRIVATE_KEY_BASE64: ${{ secrets.FLEET_APP_PRIVATE_KEY_BASE64 }}
           GITHUB_APP_INSTALLATION_ID: ${{ secrets.FLEET_APP_INSTALLATION_ID }}

--- a/.github/workflows/fleet-merge.yml
+++ b/.github/workflows/fleet-merge.yml
@@ -60,5 +60,5 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
           GITHUB_APP_ID: ${{ secrets.FLEET_APP_ID }}
-          GITHUB_APP_PRIVATE_KEY_BASE64: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          GITHUB_APP_PRIVATE_KEY_BASE64: ${{ secrets.FLEET_APP_PRIVATE_KEY_BASE64 }}
           GITHUB_APP_INSTALLATION_ID: ${{ secrets.FLEET_APP_INSTALLATION_ID }}


### PR DESCRIPTION
All three fleet workflows (merge, dispatch, analyze) now:
- Generate Fleet App installation token via create-github-app-token
- Use app token as GITHUB_TOKEN (CLA compliance)
- Use explicit FLEET_APP_PRIVATE_KEY (raw PEM) for token generation
- Use explicit FLEET_APP_PRIVATE_KEY_BASE64 for fleet handler env var
- Install @google/jules-fleet to /tmp (workspace isolation)