### PR TITLE
fix: resolve conflicts for sdk, mcp, and merge packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "jules-sdk-monorepo",
@@ -55,13 +54,13 @@
     },
     "packages/fleet": {
       "name": "@google/jules-fleet",
-      "version": "0.0.1-experimental.7",
+      "version": "0.0.1-experimental.27",
       "bin": {
         "jules-fleet": "dist/cli/index.mjs",
       },
       "dependencies": {
         "@clack/prompts": "^1.0.1",
-        "@google/jules-merge": "workspace:*",
+        "@google/jules-merge": "^0.0.2",
         "@google/jules-sdk": "^0.1.0",
         "@octokit/auth-app": "^8.2.0",
         "citty": "^0.1.6",
@@ -108,7 +107,7 @@
     },
     "packages/merge": {
       "name": "@google/jules-merge",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "bin": {
         "jules-merge": "./dist/cli/index.mjs",
       },
@@ -1086,6 +1085,8 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@google/jules-fleet/@google/jules-merge": ["@google/jules-merge@0.0.2", "", { "dependencies": { "@google/jules-sdk": "^0.1.0", "@octokit/auth-app": "^8.2.0", "@octokit/rest": "^21.0.0", "citty": "^0.1.6", "zod": "^3.25.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.1" }, "optionalPeers": ["@modelcontextprotocol/sdk"], "bin": { "jules-merge": "dist/cli/index.mjs" } }, "sha512-VPpbdBt48AbmFByg5RGztv2sQPPJ5fFJARXTvX41lY/b9M+qdyZPp19+ay3qfxEHgj1EvnRMwf/HFOrMMXZ7vQ=="],
 
     "@google/jules-fleet/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 

--- a/packages/core/src/activities/client.ts
+++ b/packages/core/src/activities/client.ts
@@ -23,6 +23,7 @@ import { Activity, Artifact } from '../types.js';
 import { ActivityStorage } from '../storage/types.js';
 import { ActivityClient, ListOptions, SelectOptions } from './types.js';
 import { isSessionFrozen } from '../utils/page-token.js';
+import { Platform } from '../platform/types.js';
 
 /**
  * Creates a filter string for the Jules API to fetch activities
@@ -57,6 +58,7 @@ export class DefaultActivityClient implements ActivityClient {
   constructor(
     private storage: ActivityStorage,
     private network: NetworkClient,
+    private platform: Platform,
   ) {}
 
   /**
@@ -98,12 +100,8 @@ export class DefaultActivityClient implements ActivityClient {
           const rawBashOutput = (artifact as any).bashOutput || artifact;
           return new BashArtifact(rawBashOutput);
         case 'media':
-          // TODO: MediaArtifact requires the platform object for some methods.
-          // However, for local cache re-hydration, we don't have access to it here.
-          // For now, we accept this limitation as the primary bug is with ChangeSetArtifact.
-          // A future refactor could pass the platform object down.
           const rawMedia = (artifact as any).media || artifact;
-          return new MediaArtifact(rawMedia, {} as any, activity.id);
+          return new MediaArtifact(rawMedia, this.platform, activity.id);
         default:
           // If we don't recognize the type, return it as-is.
           return artifact as Artifact;

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -99,7 +99,11 @@ export class SessionClientImpl implements SessionClient {
       platform,
     );
 
-    this._activities = new DefaultActivityClient(activityStorage, network);
+    this._activities = new DefaultActivityClient(
+      activityStorage,
+      network,
+      platform,
+    );
   }
 
   // Private helper wrapper to enforce resume context
@@ -409,8 +413,10 @@ export class SessionClientImpl implements SessionClient {
     const includeActivities = options?.activities ?? true;
     const [info, activities] = await Promise.all([
       this.info(),
-      includeActivities ? collectAsync(this.history()) : [],
+      includeActivities ? collectAsync(this.history()) : Promise.resolve([]),
     ]);
-    return new SessionSnapshotImpl({ data: { session: info, activities } });
+    return new SessionSnapshotImpl({
+      data: { session: info, activities: activities ?? [] },
+    });
   }
 }

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -32,7 +32,7 @@ import {
   GeneratedFile,
   SessionOutcome,
   GeneratedFiles,
-  ChangeSet,
+  ChangeSetArtifact,
   ToJSONOptions,
 } from './types.js';
 
@@ -58,7 +58,7 @@ export class SessionSnapshotImpl implements SessionSnapshot {
   readonly timeline: readonly TimelineEntry[];
   readonly insights: SessionInsights;
   readonly generatedFiles: GeneratedFiles;
-  readonly changeSet: () => ChangeSet | undefined;
+  readonly changeSet: () => ChangeSetArtifact | undefined;
 
   constructor(options: SessionSnapshotOptions) {
     const { session, activities = [] } = options.data;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1235,7 +1235,7 @@ export interface SessionSnapshot {
   readonly timeline: readonly TimelineEntry[];
   readonly insights: SessionInsights;
   readonly generatedFiles: GeneratedFiles;
-  readonly changeSet: () => ChangeSet | undefined;
+  readonly changeSet: () => ChangeSetArtifact | undefined;
   toJSON(options?: ToJSONOptions): Partial<SerializedSnapshot>;
   toMarkdown(): string;
 }

--- a/packages/core/tests/activities/client-history.test.ts
+++ b/packages/core/tests/activities/client-history.test.ts
@@ -78,7 +78,7 @@ describe('DefaultActivityClient.history()', () => {
     const storage = createMockStorage(cachedActivities);
     // Network returns empty since all activities are already cached
     const network = createMockNetwork([]);
-    const client = new DefaultActivityClient(storage, network);
+    const client = new DefaultActivityClient(storage, network, {} as any);
 
     const result: Activity[] = [];
     for await (const act of client.history()) {
@@ -102,7 +102,7 @@ describe('DefaultActivityClient.history()', () => {
 
     const storage = createMockStorage([]); // Empty cache
     const network = createMockNetwork([networkActivities]);
-    const client = new DefaultActivityClient(storage, network);
+    const client = new DefaultActivityClient(storage, network, {} as any);
 
     const result: Activity[] = [];
     for await (const act of client.history()) {
@@ -121,7 +121,7 @@ describe('DefaultActivityClient.history()', () => {
 
     const storage = createMockStorage([]);
     const network = createMockNetwork([page1, page2, page3]);
-    const client = new DefaultActivityClient(storage, network);
+    const client = new DefaultActivityClient(storage, network, {} as any);
 
     const result: Activity[] = [];
     for await (const act of client.history()) {
@@ -140,7 +140,7 @@ describe('DefaultActivityClient.history()', () => {
 
     const storage = createMockStorage([]);
     const network = createMockNetwork([activities]);
-    const client = new DefaultActivityClient(storage, network);
+    const client = new DefaultActivityClient(storage, network, {} as any);
 
     const yielded: string[] = [];
     for await (const act of client.history()) {
@@ -163,7 +163,7 @@ describe('DefaultActivityClient.hydrate()', () => {
 
     const storage = createMockStorage([]);
     const network = createMockNetwork([activities]);
-    const client = new DefaultActivityClient(storage, network);
+    const client = new DefaultActivityClient(storage, network, {} as any);
 
     const count = await client.hydrate();
 
@@ -183,7 +183,7 @@ describe('DefaultActivityClient.hydrate()', () => {
 
     const storage = createMockStorage([existing]);
     const network = createMockNetwork([[existing, newActivity]]);
-    const client = new DefaultActivityClient(storage, network);
+    const client = new DefaultActivityClient(storage, network, {} as any);
 
     const count = await client.hydrate();
 

--- a/packages/core/tests/activities/client.test.ts
+++ b/packages/core/tests/activities/client.test.ts
@@ -68,7 +68,8 @@ describe('DefaultActivityClient', () => {
       listActivities: vi.fn().mockResolvedValue({ activities: [] }),
       fetchActivity: vi.fn().mockResolvedValue(undefined),
     };
-    client = new DefaultActivityClient(storageMock, networkMock);
+    const platformMock = {} as any;
+    client = new DefaultActivityClient(storageMock, networkMock, platformMock);
   });
 
   describe('history()', () => {

--- a/packages/core/tests/incremental-sync/spec.test.ts
+++ b/packages/core/tests/incremental-sync/spec.test.ts
@@ -242,7 +242,11 @@ describe('Incremental Activity Sync Spec', async () => {
         );
         const mockNetwork = createMockNetwork(apiActivities);
 
-        const client = new DefaultActivityClient(storage, mockNetwork);
+        const client = new DefaultActivityClient(
+          storage,
+          mockNetwork,
+          {} as any,
+        );
 
         // Call hydrate
         const newCount = await client.hydrate();
@@ -308,7 +312,11 @@ describe('Incremental Activity Sync Spec', async () => {
           }
 
           const mockNetwork = createMockNetwork([]);
-          const client = new DefaultActivityClient(storage, mockNetwork);
+          const client = new DefaultActivityClient(
+            storage,
+            mockNetwork,
+            {} as any,
+          );
 
           const result = await client.hydrate();
 
@@ -352,7 +360,11 @@ describe('Incremental Activity Sync Spec', async () => {
           );
           const mockNetwork = createMockNetwork(apiActivities);
 
-          const client = new DefaultActivityClient(storage, mockNetwork);
+          const client = new DefaultActivityClient(
+            storage,
+            mockNetwork,
+            {} as any,
+          );
           const newCount = await client.hydrate();
 
           const expected = tc.then as HydrationTestCase['then'];
@@ -394,7 +406,11 @@ describe('Incremental Activity Sync Spec', async () => {
         );
         const mockNetwork = createMockNetwork(apiActivities);
 
-        const client = new DefaultActivityClient(storage, mockNetwork);
+        const client = new DefaultActivityClient(
+          storage,
+          mockNetwork,
+          {} as any,
+        );
 
         // Call stream() - which internally calls history() -> hydrate()
         // We only consume history portion (not updates which would block)

--- a/packages/core/tests/network/adapter.test.ts
+++ b/packages/core/tests/network/adapter.test.ts
@@ -22,11 +22,9 @@ import { ApiClient } from '../../src/api.js';
 const mockRequest = vi.fn();
 vi.mock('../../src/api.js', () => {
   return {
-    ApiClient: vi.fn().mockImplementation(() => {
-      return {
-        request: mockRequest,
-      };
-    }),
+    ApiClient: class {
+      request = mockRequest;
+    }
   };
 });
 

--- a/packages/mcp/src/functions/code-review.ts
+++ b/packages/mcp/src/functions/code-review.ts
@@ -344,8 +344,7 @@ export async function codeReview(
   await session.activities.hydrate();
   const snapshot = await session.snapshot();
 
-  // FIX: Ensure activities is always an array
-  const activities = snapshot.activities ?? [];
+  const activities = snapshot.activities;
 
   const status = getSemanticStatus(snapshot.state);
   const isBusy = status === 'busy';
@@ -373,11 +372,7 @@ export async function codeReview(
   } else {
     // Stable mode: use session outcome changeSet, but also get activity IDs if available
 
-    // FIX: Defensive check for changeSet being a function
-    const changeSet =
-      typeof snapshot.changeSet === 'function'
-        ? (snapshot.changeSet() as ChangeSetArtifact | undefined)
-        : undefined;
+    const changeSet = snapshot.changeSet();
 
     // Try to get activity IDs by also aggregating from activities
     const activityFiles = aggregateFromActivities(activities);

--- a/packages/mcp/src/functions/session-state.ts
+++ b/packages/mcp/src/functions/session-state.ts
@@ -154,8 +154,7 @@ export async function getSessionState(
 
   const snapshot = await session.snapshot();
 
-  // FIX: Ensure activities is always an array
-  const activities = snapshot.activities ?? [];
+  const activities = snapshot.activities;
 
   const pr = snapshot.pr;
   const lastActivity = findLastActivity(activities);

--- a/packages/mcp/src/functions/show-diff.ts
+++ b/packages/mcp/src/functions/show-diff.ts
@@ -48,8 +48,7 @@ export async function showDiff(
   await session.activities.hydrate();
   const snapshot = await session.snapshot();
 
-  // FIX: Ensure activities is always an array
-  const activities = snapshot.activities ?? [];
+  const activities = snapshot.activities;
 
   let changeSet: ChangeSetArtifact | undefined;
 
@@ -81,11 +80,7 @@ export async function showDiff(
     }
   } else {
     // Get the changeSet from the snapshot (session outcome)
-    // FIX: Defensive check for changeSet being a function
-    changeSet =
-      typeof snapshot.changeSet === 'function'
-        ? (snapshot.changeSet() as ChangeSetArtifact | undefined)
-        : undefined;
+    changeSet = snapshot.changeSet();
   }
 
   if (!changeSet) {

--- a/packages/mcp/tests/functions/null-safety.test.ts
+++ b/packages/mcp/tests/functions/null-safety.test.ts
@@ -19,10 +19,11 @@ describe('Null Safety & Resilience', () => {
     vi.restoreAllMocks();
   });
 
-  describe('Session with undefined activities (new/empty sessions)', () => {
-    it('getSessionState should handle undefined activities gracefully', async () => {
+  describe('Session with empty activities (new/empty sessions)', () => {
+    it('getSessionState should handle empty activities gracefully', async () => {
       const snapshot = createMockSnapshot({
         id: 'session-new',
+        url: 'https://jules.app/sessions/session-new',
         state: 'queued',
         title: 'New Session',
       });
@@ -30,7 +31,7 @@ describe('Null Safety & Resilience', () => {
       const mockSession = {
         snapshot: vi.fn().mockResolvedValue({
           ...snapshot,
-          activities: undefined,
+          activities: [],
         }),
         activities: {
           hydrate: vi.fn().mockResolvedValue(0),
@@ -44,9 +45,10 @@ describe('Null Safety & Resilience', () => {
       expect(result.lastActivity).toBeUndefined();
     });
 
-    it('codeReview should return empty files list when activities are undefined', async () => {
+    it('codeReview should return empty files list when activities are empty', async () => {
       const snapshot = createMockSnapshot({
         id: 'session-new',
+        url: 'https://jules.app/sessions/session-new',
         state: 'queued',
         title: 'New Session',
       });
@@ -54,7 +56,7 @@ describe('Null Safety & Resilience', () => {
       const mockSession = {
         snapshot: vi.fn().mockResolvedValue({
           ...snapshot,
-          activities: undefined,
+          activities: [],
         }),
         activities: {
           hydrate: vi.fn().mockResolvedValue(0),
@@ -66,9 +68,10 @@ describe('Null Safety & Resilience', () => {
       expect(result.files).toEqual([]);
     });
 
-    it('showDiff should return empty patch when activities are undefined and activityId is provided', async () => {
+    it('showDiff should return empty patch when activities are empty and activityId is provided', async () => {
       const snapshot = createMockSnapshot({
         id: 'session-new',
+        url: 'https://jules.app/sessions/session-new',
         state: 'queued',
         title: 'New Session',
       });
@@ -76,7 +79,7 @@ describe('Null Safety & Resilience', () => {
       const mockSession = {
         snapshot: vi.fn().mockResolvedValue({
           ...snapshot,
-          activities: undefined,
+          activities: [],
         }),
         activities: {
           hydrate: vi.fn().mockResolvedValue(0),
@@ -91,35 +94,4 @@ describe('Null Safety & Resilience', () => {
     });
   });
 
-  describe('Session with malformed changeSet (raw property vs function)', () => {
-    it('codeReview should handle non-function changeSet gracefully', async () => {
-      const snapshot = createMockSnapshot({
-        id: 'session-stable',
-        state: 'completed',
-        title: 'Completed Session',
-      });
-
-      (snapshot as any).changeSet = { gitPatch: { unidiffPatch: '' } };
-
-      mockSessionWithSnapshot(mockClient, snapshot);
-
-      const result = await codeReview(mockClient, 'session-stable');
-      expect(result.files).toEqual([]);
-    });
-
-    it('showDiff should handle non-function changeSet gracefully', async () => {
-      const snapshot = createMockSnapshot({
-        id: 'session-stable',
-        state: 'completed',
-        title: 'Completed Session',
-      });
-
-      (snapshot as any).changeSet = { gitPatch: { unidiffPatch: '' } };
-
-      mockSessionWithSnapshot(mockClient, snapshot);
-
-      const result = await showDiff(mockClient, 'session-stable');
-      expect(result.unidiffPatch).toBe('');
-    });
-  });
 });

--- a/packages/merge/AGENT_CONTEXT.md
+++ b/packages/merge/AGENT_CONTEXT.md
@@ -417,13 +417,11 @@ export async function getSessionChangedFiles(
   const isBusy = isBusyState(snapshot.state);
 
   if (isBusy) {
-    return aggregateFromActivities(snapshot.activities ?? []);
+    return aggregateFromActivities(snapshot.activities);
   }
 
   // Stable: use outcome changeSet
-  const changeSet = typeof snapshot.changeSet === 'function'
-    ? (snapshot.changeSet() as ChangeSetArtifact | undefined)
-    : undefined;
+  const changeSet = snapshot.changeSet();
 
   if (!changeSet) return [];
   const parsed = changeSet.parsed();

--- a/packages/merge/src/shared/session.ts
+++ b/packages/merge/src/shared/session.ts
@@ -45,14 +45,11 @@ export async function getSessionChangedFiles(
   const isBusy = isBusyState(snapshot.state);
 
   if (isBusy) {
-    return aggregateFromActivities(snapshot.activities ?? []);
+    return aggregateFromActivities(snapshot.activities);
   }
 
   // Stable: use outcome changeSet
-  const changeSet =
-    typeof snapshot.changeSet === 'function'
-      ? (snapshot.changeSet() as ChangeSetArtifact | undefined)
-      : undefined;
+  const changeSet = snapshot.changeSet();
 
   if (!changeSet) return [];
   const parsed = changeSet.parsed();


### PR DESCRIPTION
This PR integrates code changes across `core`, `mcp`, and `merge` packages to resolve merge conflicts associated with multiple simultaneous modifications.

Key updates:
1.  **Core Package Types**: Fixed `SessionSnapshot.changeSet` to correctly return `ChangeSetArtifact | undefined` as a typed function, eliminating the need for `typeof snapshot.changeSet === 'function'` defensive checks throughout the system.
2.  **Platform Injection**: Updated `DefaultActivityClient` initialization to accept and pass the platform down to `MediaArtifact` during rehydration.
3.  **Null-Safety Fallbacks**: Upstreamed default array behavior to `SessionClientImpl.snapshot()`, guaranteeing `activities: []` when undefined. This allowed removal of redundant `snapshot.activities ?? []` defensive assignments throughout downstream `mcp` and `merge` helper functions.
4.  **Test Updates**: Updated Vitest files in `core` and `mcp` to expect the new empty array states rather than testing for undefined and malformed properties.

---
*PR created automatically by Jules for task [11359212153181644665](https://jules.google.com/task/11359212153181644665) started by @davideast*