### PR TITLE
fix: decode base64 key in workflow — single secret, no raw PEM needed

### DIFF
--- a/.github/workflows/fleet-analyze.yml
+++ b/.github/workflows/fleet-analyze.yml
@@ -32,12 +32,17 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+      - name: Decode private key
+        run: |
+          echo "FLEET_APP_PEM<<EOF" >> $GITHUB_ENV
+          echo "${{ secrets.FLEET_APP_PRIVATE_KEY_BASE64 }}" | base64 -d >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
       - name: Generate Fleet App token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.FLEET_APP_ID }}
-          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          private-key: ${{ env.FLEET_APP_PEM }}
       - run: |
           npm install --prefix /tmp/fleet @google/jules-fleet
           /tmp/fleet/node_modules/.bin/jules-fleet analyze --goal "${{ inputs.goal }}" --milestone "${{ inputs.milestone }}"

--- a/.github/workflows/fleet-dispatch.yml
+++ b/.github/workflows/fleet-dispatch.yml
@@ -28,12 +28,17 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+      - name: Decode private key
+        run: |
+          echo "FLEET_APP_PEM<<EOF" >> $GITHUB_ENV
+          echo "${{ secrets.FLEET_APP_PRIVATE_KEY_BASE64 }}" | base64 -d >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
       - name: Generate Fleet App token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.FLEET_APP_ID }}
-          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          private-key: ${{ env.FLEET_APP_PEM }}
       - run: |
           npm install --prefix /tmp/fleet @google/jules-fleet
           /tmp/fleet/node_modules/.bin/jules-fleet dispatch --milestone ${{ inputs.milestone }}

--- a/.github/workflows/fleet-merge.yml
+++ b/.github/workflows/fleet-merge.yml
@@ -43,12 +43,17 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+      - name: Decode private key
+        run: |
+          echo "FLEET_APP_PEM<<EOF" >> $GITHUB_ENV
+          echo "${{ secrets.FLEET_APP_PRIVATE_KEY_BASE64 }}" | base64 -d >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
       - name: Generate Fleet App token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.FLEET_APP_ID }}
-          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          private-key: ${{ env.FLEET_APP_PEM }}
       - run: |
           REDISPATCH_FLAG="--redispatch"
           if [ "${{ inputs.redispatch }}" = "false" ]; then


### PR DESCRIPTION
All three fleet workflows now decode FLEET_APP_PRIVATE_KEY_BASE64 to raw PEM in a workflow step, then pass decoded PEM to create-github-app-token. Only one key secret needed.