### PR TITLE
feat(fleet): add auth mode to workflow templates

### DIFF
--- a/packages/fleet/src/__tests__/dispatch-template.test.ts
+++ b/packages/fleet/src/__tests__/dispatch-template.test.ts
@@ -98,4 +98,53 @@ describe('buildDispatchTemplate', () => {
     expect(runStep.run).toContain('--milestone');
     expect(runStep.run).toContain('matrix.milestone');
   });
+
+  it('default auth does NOT include decode/app-token steps', () => {
+    const parsed = yaml.parse(template.content);
+    const steps = parsed.jobs.dispatch.steps;
+    expect(steps.find((s: { name?: string }) => s.name === 'Decode private key')).toBeUndefined();
+    expect(steps.find((s: { uses?: string }) => s.uses?.includes('create-github-app-token'))).toBeUndefined();
+  });
+});
+
+describe('buildDispatchTemplate with auth=app', () => {
+  const template = buildDispatchTemplate(360, 'app');
+
+  it('content is valid YAML', () => {
+    expect(() => yaml.parse(template.content)).not.toThrow();
+  });
+
+  it('includes a Decode private key step', () => {
+    const parsed = yaml.parse(template.content);
+    const steps = parsed.jobs.dispatch.steps;
+    const decodeStep = steps.find((s: { name?: string }) => s.name === 'Decode private key');
+    expect(decodeStep).toBeDefined();
+    expect(decodeStep.run).toContain('base64 -d');
+    expect(decodeStep.run).toContain('GITHUB_OUTPUT');
+  });
+
+  it('includes create-github-app-token step', () => {
+    const parsed = yaml.parse(template.content);
+    const steps = parsed.jobs.dispatch.steps;
+    const tokenStep = steps.find((s: { uses?: string }) => s.uses?.includes('create-github-app-token'));
+    expect(tokenStep).toBeDefined();
+    expect(tokenStep.with['app-id']).toContain('FLEET_APP_ID');
+    expect(tokenStep.with['private-key']).toContain('decode-key.outputs.pem');
+  });
+
+  it('uses app token as GITHUB_TOKEN', () => {
+    const parsed = yaml.parse(template.content);
+    const runStep = parsed.jobs.dispatch.steps.find(
+      (s: { run?: string }) => s.run?.includes('jules-fleet'),
+    );
+    expect(runStep.env.GITHUB_TOKEN).toContain('app-token.outputs.token');
+  });
+
+  it('uses FLEET_APP_PRIVATE_KEY_BASE64 secret name', () => {
+    const parsed = yaml.parse(template.content);
+    const runStep = parsed.jobs.dispatch.steps.find(
+      (s: { run?: string }) => s.run?.includes('jules-fleet'),
+    );
+    expect(runStep.env.GITHUB_APP_PRIVATE_KEY_BASE64).toContain('FLEET_APP_PRIVATE_KEY_BASE64');
+  });
 });

--- a/packages/fleet/src/__tests__/merge-template.test.ts
+++ b/packages/fleet/src/__tests__/merge-template.test.ts
@@ -94,4 +94,61 @@ describe('buildMergeTemplate', () => {
     // Different intervals should produce different cron expressions
     expect(parsed60.on.schedule[0].cron).not.toBe(parsed360.on.schedule[0].cron);
   });
+
+  it('default auth does NOT include decode/app-token steps', () => {
+    const parsed = yaml.parse(template.content);
+    const steps = parsed.jobs.merge.steps;
+    expect(steps.find((s: { name?: string }) => s.name === 'Decode private key')).toBeUndefined();
+    expect(steps.find((s: { uses?: string }) => s.uses?.includes('create-github-app-token'))).toBeUndefined();
+  });
+
+  it('default auth uses secrets.GITHUB_TOKEN', () => {
+    const parsed = yaml.parse(template.content);
+    const runStep = parsed.jobs.merge.steps.find(
+      (s: { run?: string }) => s.run?.includes('jules-fleet'),
+    );
+    expect(runStep.env.GITHUB_TOKEN).toContain('secrets.GITHUB_TOKEN');
+  });
+});
+
+describe('buildMergeTemplate with auth=app', () => {
+  const template = buildMergeTemplate(60, 'app');
+
+  it('content is valid YAML', () => {
+    expect(() => yaml.parse(template.content)).not.toThrow();
+  });
+
+  it('includes a Decode private key step', () => {
+    const parsed = yaml.parse(template.content);
+    const steps = parsed.jobs.merge.steps;
+    const decodeStep = steps.find((s: { name?: string }) => s.name === 'Decode private key');
+    expect(decodeStep).toBeDefined();
+    expect(decodeStep.run).toContain('base64 -d');
+    expect(decodeStep.run).toContain('GITHUB_OUTPUT');
+  });
+
+  it('includes create-github-app-token step', () => {
+    const parsed = yaml.parse(template.content);
+    const steps = parsed.jobs.merge.steps;
+    const tokenStep = steps.find((s: { uses?: string }) => s.uses?.includes('create-github-app-token'));
+    expect(tokenStep).toBeDefined();
+    expect(tokenStep.with['app-id']).toContain('FLEET_APP_ID');
+    expect(tokenStep.with['private-key']).toContain('decode-key.outputs.pem');
+  });
+
+  it('uses app token as GITHUB_TOKEN', () => {
+    const parsed = yaml.parse(template.content);
+    const runStep = parsed.jobs.merge.steps.find(
+      (s: { run?: string }) => s.run?.includes('jules-fleet'),
+    );
+    expect(runStep.env.GITHUB_TOKEN).toContain('app-token.outputs.token');
+  });
+
+  it('uses FLEET_APP_PRIVATE_KEY_BASE64 secret name', () => {
+    const parsed = yaml.parse(template.content);
+    const runStep = parsed.jobs.merge.steps.find(
+      (s: { run?: string }) => s.run?.includes('jules-fleet'),
+    );
+    expect(runStep.env.GITHUB_APP_PRIVATE_KEY_BASE64).toContain('FLEET_APP_PRIVATE_KEY_BASE64');
+  });
 });

--- a/packages/fleet/src/__tests__/workflow-template-guardrails.test.ts
+++ b/packages/fleet/src/__tests__/workflow-template-guardrails.test.ts
@@ -193,4 +193,35 @@ describe('Workflow Template Guardrails', () => {
     });
     expect(new Set(names).size).toBe(names.length);
   });
+
+  // ── Secret naming consistency ──────────────────────────────────────
+
+  it('PRIVATE_KEY_BASE64 env var always maps to _BASE64 secret', () => {
+    for (const template of ALL_TEMPLATES) {
+      const parsed = yaml.parse(template.content);
+      const steps = extractSteps(parsed);
+      for (const step of steps) {
+        const env = (step as Record<string, unknown>).env as Record<string, string> | undefined;
+        if (!env) continue;
+        const base64Var = env['GITHUB_APP_PRIVATE_KEY_BASE64'];
+        if (base64Var) {
+          expect(base64Var).toContain('FLEET_APP_PRIVATE_KEY_BASE64');
+        }
+      }
+    }
+  });
+
+  // ── Auth=app templates ─────────────────────────────────────────────
+
+  it('auth=app templates are valid YAML', () => {
+    const appTemplates = buildWorkflowTemplates(60, 'app');
+    for (const t of appTemplates) {
+      expect(() => yaml.parse(t.content)).not.toThrow();
+    }
+  });
+
+  it('auth=app templates have same count as default templates', () => {
+    const appTemplates = buildWorkflowTemplates(60, 'app');
+    expect(appTemplates.length).toBe(ALL_TEMPLATES.length);
+  });
 });

--- a/packages/fleet/src/init/templates.ts
+++ b/packages/fleet/src/init/templates.ts
@@ -35,12 +35,17 @@ import type { WorkflowTemplate } from './templates/types.js';
 /**
  * Build all workflow templates with a configurable interval.
  * @param intervalMinutes - Pipeline cadence in minutes (default: 360 = 6 hours)
+ * @param auth - Authentication mode: 'token' uses secrets.GITHUB_TOKEN,
+ *               'app' generates a GitHub App token for CLA-safe commits
  */
-export function buildWorkflowTemplates(intervalMinutes = 360): readonly WorkflowTemplate[] {
+export function buildWorkflowTemplates(
+  intervalMinutes = 360,
+  auth: 'token' | 'app' = 'token',
+): readonly WorkflowTemplate[] {
   return [
-    buildAnalyzeTemplate(intervalMinutes),
-    buildDispatchTemplate(intervalMinutes),
-    buildMergeTemplate(intervalMinutes),
+    buildAnalyzeTemplate(intervalMinutes, auth),
+    buildDispatchTemplate(intervalMinutes, auth),
+    buildMergeTemplate(intervalMinutes, auth),
     CONFLICT_DETECTION_TEMPLATE,
     FLEET_LABEL_TEMPLATE,
   ];

--- a/packages/fleet/src/init/templates/analyze.ts
+++ b/packages/fleet/src/init/templates/analyze.ts
@@ -15,7 +15,7 @@
 import type { WorkflowTemplate } from './types.js';
 import { buildCron } from './cron.js';
 
-export function buildAnalyzeTemplate(intervalMinutes: number): WorkflowTemplate {
+export function buildAnalyzeTemplate(intervalMinutes: number, auth: 'token' | 'app' = 'token'): WorkflowTemplate {
   const cron = buildCron(intervalMinutes);
   return {
     repoPath: '.github/workflows/fleet-analyze.yml',
@@ -53,13 +53,29 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '22'${auth === 'app' ? `
+      - name: Decode private key
+        id: decode-key
+        run: |
+          echo "\${{ secrets.FLEET_APP_PRIVATE_KEY_BASE64 }}" | base64 -d > /tmp/fleet-app-key.pem
+          {
+            echo "pem<<PEMEOF"
+            cat /tmp/fleet-app-key.pem
+            echo "PEMEOF"
+          } >> "\$GITHUB_OUTPUT"
+          rm /tmp/fleet-app-key.pem
+      - name: Generate Fleet App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: \${{ secrets.FLEET_APP_ID }}
+          private-key: \${{ steps.decode-key.outputs.pem }}` : ''}
       - run: npx -y --package=@google/jules-fleet jules-fleet analyze --goal "\${{ inputs.goal }}" --milestone "\${{ inputs.milestone }}"
         env:
-          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: \${{ ${auth === 'app' ? 'steps.app-token.outputs.token' : 'secrets.GITHUB_TOKEN'} }}
           JULES_API_KEY: \${{ secrets.JULES_API_KEY }}
           GITHUB_APP_ID: \${{ secrets.FLEET_APP_ID }}
-          GITHUB_APP_PRIVATE_KEY_BASE64: \${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          GITHUB_APP_PRIVATE_KEY_BASE64: \${{ secrets.FLEET_APP_PRIVATE_KEY_BASE64 }}
           GITHUB_APP_INSTALLATION_ID: \${{ secrets.FLEET_APP_INSTALLATION_ID }}
 `,
   };

--- a/packages/fleet/src/init/templates/dispatch.ts
+++ b/packages/fleet/src/init/templates/dispatch.ts
@@ -15,7 +15,7 @@
 import type { WorkflowTemplate } from './types.js';
 import { buildCron, dispatchOffset } from './cron.js';
 
-export function buildDispatchTemplate(intervalMinutes: number): WorkflowTemplate {
+export function buildDispatchTemplate(intervalMinutes: number, auth: 'token' | 'app' = 'token'): WorkflowTemplate {
   const cron = buildCron(intervalMinutes, dispatchOffset(intervalMinutes));
   return {
     repoPath: '.github/workflows/fleet-dispatch.yml',
@@ -71,13 +71,29 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '22'${auth === 'app' ? `
+      - name: Decode private key
+        id: decode-key
+        run: |
+          echo "\${{ secrets.FLEET_APP_PRIVATE_KEY_BASE64 }}" | base64 -d > /tmp/fleet-app-key.pem
+          {
+            echo "pem<<PEMEOF"
+            cat /tmp/fleet-app-key.pem
+            echo "PEMEOF"
+          } >> "\$GITHUB_OUTPUT"
+          rm /tmp/fleet-app-key.pem
+      - name: Generate Fleet App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: \${{ secrets.FLEET_APP_ID }}
+          private-key: \${{ steps.decode-key.outputs.pem }}` : ''}
       - run: npx -y --package=@google/jules-fleet jules-fleet dispatch --milestone \${{ matrix.milestone }}
         env:
-          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: \${{ ${auth === 'app' ? 'steps.app-token.outputs.token' : 'secrets.GITHUB_TOKEN'} }}
           JULES_API_KEY: \${{ secrets.JULES_API_KEY }}
           GITHUB_APP_ID: \${{ secrets.FLEET_APP_ID }}
-          GITHUB_APP_PRIVATE_KEY_BASE64: \${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          GITHUB_APP_PRIVATE_KEY_BASE64: \${{ secrets.FLEET_APP_PRIVATE_KEY_BASE64 }}
           GITHUB_APP_INSTALLATION_ID: \${{ secrets.FLEET_APP_INSTALLATION_ID }}
 `,
   };

--- a/packages/fleet/src/init/templates/merge.ts
+++ b/packages/fleet/src/init/templates/merge.ts
@@ -15,7 +15,7 @@
 import type { WorkflowTemplate } from './types.js';
 import { buildCron, mergeInterval } from './cron.js';
 
-export function buildMergeTemplate(intervalMinutes: number): WorkflowTemplate {
+export function buildMergeTemplate(intervalMinutes: number, auth: 'token' | 'app' = 'token'): WorkflowTemplate {
   const cron = buildCron(mergeInterval(intervalMinutes));
   return {
     repoPath: '.github/workflows/fleet-merge.yml',
@@ -64,7 +64,23 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '22'${auth === 'app' ? `
+      - name: Decode private key
+        id: decode-key
+        run: |
+          echo "\${{ secrets.FLEET_APP_PRIVATE_KEY_BASE64 }}" | base64 -d > /tmp/fleet-app-key.pem
+          {
+            echo "pem<<PEMEOF"
+            cat /tmp/fleet-app-key.pem
+            echo "PEMEOF"
+          } >> "\$GITHUB_OUTPUT"
+          rm /tmp/fleet-app-key.pem
+      - name: Generate Fleet App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: \${{ secrets.FLEET_APP_ID }}
+          private-key: \${{ steps.decode-key.outputs.pem }}` : ''}
       - run: |
           REDISPATCH_FLAG="--redispatch"
           if [ "\${{ inputs.redispatch }}" = "false" ]; then
@@ -72,10 +88,10 @@ jobs:
           fi
           npx -y --package=@google/jules-fleet jules-fleet merge --mode \${{ inputs.mode || 'label' }} --run-id "\${{ inputs.fleet_run_id }}" \$REDISPATCH_FLAG
         env:
-          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: \${{ ${auth === 'app' ? 'steps.app-token.outputs.token' : 'secrets.GITHUB_TOKEN'} }}
           JULES_API_KEY: \${{ secrets.JULES_API_KEY }}
           GITHUB_APP_ID: \${{ secrets.FLEET_APP_ID }}
-          GITHUB_APP_PRIVATE_KEY_BASE64: \${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          GITHUB_APP_PRIVATE_KEY_BASE64: \${{ secrets.FLEET_APP_PRIVATE_KEY_BASE64 }}
           GITHUB_APP_INSTALLATION_ID: \${{ secrets.FLEET_APP_INSTALLATION_ID }}
 `,
   };


### PR DESCRIPTION
Adds an 'auth' parameter to buildMergeTemplate, buildDispatchTemplate, buildAnalyzeTemplate, and buildWorkflowTemplates. When auth='app':
- Injects decode step (base64 → PEM via GITHUB_OUTPUT)
- Injects create-github-app-token@v1 step
- Swaps GITHUB_TOKEN to use app token output

Also fixes incorrect secret name in all templates: FLEET_APP_PRIVATE_KEY → FLEET_APP_PRIVATE_KEY_BASE64

Includes 9 new tests covering both auth modes and guardrails.