### PR TITLE
feat(fleet): add --create-repo to init command with --json agent input

### DIFF
--- a/packages/fleet/src/__tests__/create-repo-op.test.ts
+++ b/packages/fleet/src/__tests__/create-repo-op.test.ts
@@ -1,0 +1,155 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi } from 'vitest';
+import { createRepo } from '../init/ops/create-repo.js';
+import type { FleetEvent } from '../shared/events.js';
+
+/**
+ * Create a mock Octokit with configurable behavior for repo creation tests.
+ */
+function mockOctokit(overrides: {
+  userType?: 'Organization' | 'User';
+  createInOrgResult?: Record<string, unknown>;
+  createForUserResult?: Record<string, unknown>;
+  createInOrgError?: { status: number; message: string };
+  createForUserError?: { status: number; message: string };
+  getUserError?: { status: number; message: string };
+} = {}) {
+  const defaults = {
+    full_name: 'test-org/new-repo',
+    html_url: 'https://github.com/test-org/new-repo',
+    clone_url: 'https://github.com/test-org/new-repo.git',
+  };
+
+  return {
+    rest: {
+      users: {
+        getByUsername: overrides.getUserError
+          ? vi.fn().mockRejectedValue(Object.assign(new Error(overrides.getUserError.message), { status: overrides.getUserError.status }))
+          : vi.fn().mockResolvedValue({ data: { type: overrides.userType ?? 'Organization' } }),
+      },
+      repos: {
+        createInOrg: overrides.createInOrgError
+          ? vi.fn().mockRejectedValue(Object.assign(new Error(overrides.createInOrgError.message), { status: overrides.createInOrgError.status }))
+          : vi.fn().mockResolvedValue({ data: overrides.createInOrgResult ?? defaults }),
+        createForAuthenticatedUser: overrides.createForUserError
+          ? vi.fn().mockRejectedValue(Object.assign(new Error(overrides.createForUserError.message), { status: overrides.createForUserError.status }))
+          : vi.fn().mockResolvedValue({ data: overrides.createForUserResult ?? defaults }),
+      },
+    },
+  } as any;
+}
+
+describe('createRepo operation', () => {
+  it('creates repo in org when owner is Organization', async () => {
+    const octokit = mockOctokit({ userType: 'Organization' });
+    const events: FleetEvent[] = [];
+    const result = await createRepo(
+      octokit, 'test-org', 'new-repo', { visibility: 'private' }, (e: FleetEvent) => events.push(e),
+    );
+
+    expect('success' in result).toBe(false); // Not a fail result — it's the data
+    expect(result).toEqual({
+      fullName: 'test-org/new-repo',
+      url: 'https://github.com/test-org/new-repo',
+      cloneUrl: 'https://github.com/test-org/new-repo.git',
+    });
+    expect(octokit.rest.repos.createInOrg).toHaveBeenCalledWith(
+      expect.objectContaining({ org: 'test-org', name: 'new-repo', visibility: 'private' }),
+    );
+  });
+
+  it('creates repo for user when owner is User', async () => {
+    const octokit = mockOctokit({ userType: 'User' });
+    const events: FleetEvent[] = [];
+    const result = await createRepo(
+      octokit, 'my-user', 'new-repo', { visibility: 'public' }, (e: FleetEvent) => events.push(e),
+    );
+
+    expect('success' in result).toBe(false);
+    expect(octokit.rest.repos.createForAuthenticatedUser).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'new-repo', private: false }),
+    );
+  });
+
+  it('returns REPO_CREATE_FAILED on 422 (name taken)', async () => {
+    const octokit = mockOctokit({
+      userType: 'Organization',
+      createInOrgError: { status: 422, message: 'Repository creation failed.' },
+    });
+    const events: FleetEvent[] = [];
+    const result = await createRepo(
+      octokit, 'test-org', 'existing-repo', { visibility: 'private' }, (e: FleetEvent) => events.push(e),
+    );
+
+    expect('success' in result).toBe(true);
+    if ('success' in result && !result.success) {
+      expect(result.error.code).toBe('REPO_CREATE_FAILED');
+    }
+  });
+
+  it('returns REPO_CREATE_FAILED on 403 (insufficient perms)', async () => {
+    const octokit = mockOctokit({
+      userType: 'Organization',
+      createInOrgError: { status: 403, message: 'Resource not accessible by integration' },
+    });
+    const events: FleetEvent[] = [];
+    const result = await createRepo(
+      octokit, 'test-org', 'new-repo', { visibility: 'private' }, (e: FleetEvent) => events.push(e),
+    );
+
+    expect('success' in result).toBe(true);
+    if ('success' in result && !result.success) {
+      expect(result.error.code).toBe('REPO_CREATE_FAILED');
+      expect(result.error.message).toContain('Resource not accessible');
+    }
+  });
+
+  it('emits repo:creating and repo:created events on success', async () => {
+    const octokit = mockOctokit();
+    const events: FleetEvent[] = [];
+    await createRepo(octokit, 'test-org', 'new-repo', { visibility: 'private' }, (e: FleetEvent) => events.push(e));
+
+    const types = events.map((e: FleetEvent) => e.type);
+    expect(types).toContain('init:repo:creating');
+    expect(types).toContain('init:repo:created');
+  });
+
+  it('emits repo:failed event on error', async () => {
+    const octokit = mockOctokit({
+      userType: 'Organization',
+      createInOrgError: { status: 422, message: 'Repo exists' },
+    });
+    const events: FleetEvent[] = [];
+    await createRepo(octokit, 'test-org', 'new-repo', { visibility: 'private' }, (e: FleetEvent) => events.push(e));
+
+    const failEvent = events.find((e: FleetEvent) => e.type === 'init:repo:failed');
+    expect(failEvent).toBeDefined();
+  });
+
+  it('passes description when provided', async () => {
+    const octokit = mockOctokit({ userType: 'Organization' });
+    const events: FleetEvent[] = [];
+    await createRepo(
+      octokit, 'test-org', 'new-repo',
+      { visibility: 'private', description: 'My awesome repo' },
+      (e: FleetEvent) => events.push(e),
+    );
+
+    expect(octokit.rest.repos.createInOrg).toHaveBeenCalledWith(
+      expect.objectContaining({ description: 'My awesome repo' }),
+    );
+  });
+});

--- a/packages/fleet/src/__tests__/init-create-repo-handler.test.ts
+++ b/packages/fleet/src/__tests__/init-create-repo-handler.test.ts
@@ -1,0 +1,150 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi } from 'vitest';
+import { InitHandler } from '../init/handler.js';
+import type { Octokit } from 'octokit';
+import type { FleetEvent } from '../shared/events.js';
+
+/**
+ * Extended mock Octokit that includes repo creation APIs
+ * alongside the existing init APIs (git, repos, pulls).
+ */
+function createMockOctokit(overrides: {
+  /** Whether the repo already exists (GET /repos succeeds) */
+  repoExists?: boolean;
+  /** Owner type for user detection */
+  userType?: 'Organization' | 'User';
+  /** If true, repo creation throws 403 */
+  repoCreateFails403?: boolean;
+  /** If true, repo creation throws 422 */
+  repoCreateFails422?: boolean;
+} = {}): Octokit {
+  const repoDefaults = {
+    full_name: 'o/r',
+    html_url: 'https://github.com/o/r',
+    clone_url: 'https://github.com/o/r.git',
+  };
+
+  return {
+    rest: {
+      git: {
+        getRef: vi.fn().mockResolvedValue({
+          data: { object: { sha: 'abc123' } },
+        }),
+        createRef: vi.fn().mockResolvedValue({ data: {} }),
+      },
+      repos: {
+        get: overrides.repoExists === false
+          ? vi.fn().mockRejectedValue(Object.assign(new Error('Not Found'), { status: 404 }))
+          : vi.fn().mockResolvedValue({ data: repoDefaults }),
+        createOrUpdateFileContents: vi.fn().mockResolvedValue({ data: {} }),
+        createInOrg: overrides.repoCreateFails403
+          ? vi.fn().mockRejectedValue(Object.assign(new Error('Resource not accessible'), { status: 403 }))
+          : overrides.repoCreateFails422
+            ? vi.fn().mockRejectedValue(Object.assign(new Error('Repo exists'), { status: 422 }))
+            : vi.fn().mockResolvedValue({ data: repoDefaults }),
+        createForAuthenticatedUser: vi.fn().mockResolvedValue({ data: repoDefaults }),
+      },
+      pulls: {
+        create: vi.fn().mockResolvedValue({
+          data: { html_url: 'https://github.com/o/r/pull/1', number: 1 },
+        }),
+      },
+      users: {
+        getByUsername: vi.fn().mockResolvedValue({
+          data: { type: overrides.userType ?? 'Organization' },
+        }),
+      },
+    },
+  } as unknown as Octokit;
+}
+
+const baseInput = {
+  owner: 'o',
+  repoName: 'r',
+  baseBranch: 'main',
+  overwrite: false,
+  intervalMinutes: 360,
+  auth: 'token' as const,
+  visibility: 'private' as const,
+  createRepo: false,
+};
+
+describe('InitHandler with createRepo', () => {
+  it('creates repo then proceeds with init when createRepo=true and repo does not exist', async () => {
+    const octokit = createMockOctokit({ repoExists: false });
+    const events: FleetEvent[] = [];
+    const handler = new InitHandler({ octokit, emit: (e: FleetEvent) => events.push(e) });
+
+    const result = await handler.execute({ ...baseInput, createRepo: true, visibility: 'private' });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.repoCreated).toBe(true);
+      expect(result.data.prUrl).toBe('https://github.com/o/r/pull/1');
+    }
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain('init:repo:creating');
+    expect(types).toContain('init:repo:created');
+    expect(types).toContain('init:branch:created');
+    expect(types).toContain('init:pr:created');
+  });
+
+  it('skips repo creation when createRepo=true but repo already exists', async () => {
+    const octokit = createMockOctokit({ repoExists: true });
+    const events: FleetEvent[] = [];
+    const handler = new InitHandler({ octokit, emit: (e: FleetEvent) => events.push(e) });
+
+    const result = await handler.execute({ ...baseInput, createRepo: true, visibility: 'private' });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.repoCreated).toBeUndefined();
+    }
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain('init:repo:exists');
+    expect(types).not.toContain('init:repo:creating');
+  });
+
+  it('returns REPO_CREATE_FAILED when creation fails with 403', async () => {
+    const octokit = createMockOctokit({ repoExists: false, repoCreateFails403: true });
+    const events: FleetEvent[] = [];
+    const handler = new InitHandler({ octokit, emit: (e: FleetEvent) => events.push(e) });
+
+    const result = await handler.execute({ ...baseInput, createRepo: true, visibility: 'private' });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe('REPO_CREATE_FAILED');
+      expect(result.error.message).toContain('Resource not accessible');
+    }
+  });
+
+  it('does not create repo when createRepo is false (default behavior)', async () => {
+    const octokit = createMockOctokit();
+    const events: FleetEvent[] = [];
+    const handler = new InitHandler({ octokit, emit: (e: FleetEvent) => events.push(e) });
+
+    const result = await handler.execute(baseInput);
+
+    expect(result.success).toBe(true);
+
+    const types = events.map((e) => e.type);
+    expect(types).not.toContain('init:repo:creating');
+    expect(types).not.toContain('init:repo:exists');
+  });
+});

--- a/packages/fleet/src/__tests__/init-create-repo-spec.test.ts
+++ b/packages/fleet/src/__tests__/init-create-repo-spec.test.ts
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import { InitInputSchema, InitErrorCode } from '../init/spec.js';
+
+describe('InitInputSchema — createRepo fields', () => {
+  const baseInput = {
+    owner: 'test-org',
+    repoName: 'test-repo',
+    baseBranch: 'main',
+  };
+
+  it('defaults createRepo to false', () => {
+    const result = InitInputSchema.parse(baseInput);
+    expect(result.createRepo).toBe(false);
+  });
+
+  it('accepts createRepo: true', () => {
+    const result = InitInputSchema.parse({ ...baseInput, createRepo: true });
+    expect(result.createRepo).toBe(true);
+  });
+
+  it('defaults visibility to private', () => {
+    const result = InitInputSchema.parse({ ...baseInput, createRepo: true });
+    expect(result.visibility).toBe('private');
+  });
+
+  it('accepts visibility: public', () => {
+    const result = InitInputSchema.parse({ ...baseInput, createRepo: true, visibility: 'public' });
+    expect(result.visibility).toBe('public');
+  });
+
+  it('rejects invalid visibility value', () => {
+    expect(() =>
+      InitInputSchema.parse({ ...baseInput, visibility: 'internal' }),
+    ).toThrow();
+  });
+
+  it('accepts optional description', () => {
+    const result = InitInputSchema.parse({ ...baseInput, createRepo: true, description: 'My repo' });
+    expect(result.description).toBe('My repo');
+  });
+
+  it('description is undefined by default', () => {
+    const result = InitInputSchema.parse(baseInput);
+    expect(result.description).toBeUndefined();
+  });
+});
+
+describe('InitErrorCode — REPO_CREATE_FAILED', () => {
+  it('includes REPO_CREATE_FAILED in error codes', () => {
+    const result = InitErrorCode.parse('REPO_CREATE_FAILED');
+    expect(result).toBe('REPO_CREATE_FAILED');
+  });
+});

--- a/packages/fleet/src/__tests__/resolve-input.test.ts
+++ b/packages/fleet/src/__tests__/resolve-input.test.ts
@@ -1,0 +1,58 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import { resolveInput } from '../shared/cli/input.js';
+import { z } from 'zod';
+
+const TestSchema = z.object({
+  name: z.string().min(1),
+  count: z.number().default(1),
+  enabled: z.boolean().default(false),
+});
+
+describe('resolveInput', () => {
+  it('parses JSON string through Zod schema', () => {
+    const result = resolveInput(TestSchema, '{"name":"hello","count":5}');
+    expect(result).toEqual({ name: 'hello', count: 5, enabled: false });
+  });
+
+  it('applies schema defaults to JSON input', () => {
+    const result = resolveInput(TestSchema, '{"name":"hello"}');
+    expect(result.count).toBe(1);
+    expect(result.enabled).toBe(false);
+  });
+
+  it('falls back to flagInput when no JSON provided', () => {
+    const result = resolveInput(TestSchema, undefined, { name: 'from-flags', count: 3 });
+    expect(result).toEqual({ name: 'from-flags', count: 3, enabled: false });
+  });
+
+  it('throws on invalid JSON string', () => {
+    expect(() => resolveInput(TestSchema, '{bad json}')).toThrow();
+  });
+
+  it('throws on schema validation failure', () => {
+    expect(() => resolveInput(TestSchema, '{"name":""}')).toThrow();
+  });
+
+  it('JSON takes precedence over flagInput', () => {
+    const result = resolveInput(
+      TestSchema,
+      '{"name":"from-json"}',
+      { name: 'from-flags' },
+    );
+    expect(result.name).toBe('from-json');
+  });
+});

--- a/packages/fleet/src/cli/init.command.ts
+++ b/packages/fleet/src/cli/init.command.ts
@@ -13,17 +13,18 @@
 // limitations under the License.
 
 import { defineCommand } from 'citty';
-import { InitInputSchema } from '../init/spec.js';
+import { InitInputSchema, type InitInput } from '../init/spec.js';
 import { InitHandler } from '../init/handler.js';
 import { ConfigureHandler } from '../configure/handler.js';
 import { createFleetOctokit } from '../shared/auth/octokit.js';
 import { createRenderer, createEmitter, isInteractive } from '../shared/ui/index.js';
 import { runInitWizard, validateHeadlessInputs } from '../init/wizard/index.js';
-import type { InitArgs } from '../init/wizard/types.js';
+import type { InitArgs, InitWizardResult } from '../init/wizard/types.js';
 import { uploadSecret } from '../init/ops/upload-secrets.js';
 import { WORKFLOW_TEMPLATES, buildWorkflowTemplates } from '../init/templates.js';
 import { parseFeatureFlags } from '../init/wizard/parse-features.js';
 import { outputArgs, renderResult, resolveOutputFormat } from '../shared/cli/output.js';
+import { inputArgs, resolveInput } from '../shared/cli/input.js';
 
 export default defineCommand({
   meta: {
@@ -92,7 +93,22 @@ export default defineCommand({
       description: 'Overwrite existing workflow files (default: false)',
       default: false,
     },
+    'create-repo': {
+      type: 'boolean',
+      description: 'Create the repo if it does not exist (default: false)',
+      default: false,
+    },
+    visibility: {
+      type: 'string',
+      description: 'Repo visibility when creating: public | private (default: private)',
+      default: 'private',
+    },
+    description: {
+      type: 'string',
+      description: 'Repo description when creating',
+    },
     ...outputArgs,
+    ...inputArgs,
   },
   async run({ args }) {
     const nonInteractive = args['non-interactive'] || !isInteractive();
@@ -118,10 +134,10 @@ export default defineCommand({
       process.exit(1);
     }
 
-    const { owner, repo, baseBranch, secretsToUpload, dryRun, overwrite } = inputs as Exclude<typeof inputs, { success: false }>;
+    const wizardResult = inputs as InitWizardResult;
+    const { owner, repo, baseBranch, secretsToUpload, dryRun, overwrite } = wizardResult;
 
     // ── Parse feature flags ──
-    const wizardResult = inputs as Exclude<typeof inputs, { success: false }>;
     const features = wizardResult.features ?? parseFeatureFlags(args as unknown as InitArgs);
     const intervalMinutes = wizardResult.intervalMinutes ?? 360;
     renderer.start(`Fleet Init — ${owner}/${repo}`);
@@ -143,7 +159,7 @@ export default defineCommand({
     }
 
     // ── Execute init pipeline ──
-    const input = InitInputSchema.parse({
+    const input = resolveInput<InitInput>(InitInputSchema, args.json as string | undefined, {
       repo: `${owner}/${repo}`,
       owner,
       repoName: repo,
@@ -152,6 +168,9 @@ export default defineCommand({
       features,
       intervalMinutes,
       auth: wizardResult.authMethod,
+      createRepo: args['create-repo'] ?? wizardResult.createRepo ?? false,
+      visibility: args.visibility ?? wizardResult.visibility ?? 'private',
+      description: args.description ?? wizardResult.description,
     });
 
     const octokit = createFleetOctokit();

--- a/packages/fleet/src/init/handler.ts
+++ b/packages/fleet/src/init/handler.ts
@@ -23,6 +23,7 @@ import type { FleetEmitter } from '../shared/events.js';
 import { createBranch, isBranchResult } from './ops/create-branch.js';
 import { commitFiles, isCommitResult } from './ops/commit-files.js';
 import { createInitPR, isPRResult } from './ops/create-pr.js';
+import { createRepo, isRepoResult } from './ops/create-repo.js';
 import { execSync } from 'node:child_process';
 
 /**
@@ -67,6 +68,34 @@ export class InitHandler implements InitSpec {
     try {
       const { owner, repoName: repo, baseBranch, overwrite } = input;
       this.emit({ type: 'init:start', owner, repo });
+
+      // 0. Create repo if requested
+      let repoCreated: boolean | undefined;
+      if (input.createRepo) {
+        // Check if repo already exists
+        let repoExists = true;
+        try {
+          await (this.octokit as any).rest.repos.get({ owner, repo });
+        } catch (error: any) {
+          if (error?.status === 404) {
+            repoExists = false;
+          } else {
+            throw error;
+          }
+        }
+
+        if (repoExists) {
+          this.emit({ type: 'init:repo:exists', fullName: `${owner}/${repo}` });
+        } else {
+          const repoResult = await createRepo(
+            this.octokit, owner, repo,
+            { visibility: input.visibility ?? 'private', description: input.description },
+            this.emit,
+          );
+          if (isRepoResult(repoResult)) return repoResult;
+          repoCreated = true;
+        }
+      }
 
       // 1. Create branch
       const branchResult = await createBranch(
@@ -153,7 +182,7 @@ export class InitHandler implements InitSpec {
         labels: labelsCreated,
       });
 
-      return ok({ prUrl, prNumber, filesCreated, labelsCreated });
+      return ok({ prUrl, prNumber, filesCreated, labelsCreated, repoCreated });
     } catch (error) {
       return fail(
         'UNKNOWN_ERROR',

--- a/packages/fleet/src/init/ops/create-repo.ts
+++ b/packages/fleet/src/init/ops/create-repo.ts
@@ -1,0 +1,93 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Octokit } from 'octokit';
+import { fail } from '../../shared/result/index.js';
+import type { InitResult } from '../spec.js';
+import type { FleetEmitter } from '../../shared/events.js';
+
+export interface CreateRepoOptions {
+  visibility: 'public' | 'private';
+  description?: string;
+}
+
+export interface CreateRepoData {
+  fullName: string;
+  url: string;
+  cloneUrl: string;
+}
+
+/**
+ * Create a GitHub repository. Detects whether the owner is an org or user
+ * and calls the appropriate API endpoint.
+ *
+ * Returns repo data on success, or a fail Result on error.
+ */
+export async function createRepo(
+  octokit: Octokit,
+  owner: string,
+  name: string,
+  options: CreateRepoOptions,
+  emit: FleetEmitter,
+): Promise<CreateRepoData | InitResult> {
+  emit({ type: 'init:repo:creating', owner, name });
+
+  try {
+    // Detect org vs user
+    const { data: user } = await (octokit as any).rest.users.getByUsername({ username: owner });
+    const isOrg = user.type === 'Organization';
+
+    let data: any;
+    if (isOrg) {
+      const response = await octokit.rest.repos.createInOrg({
+        org: owner,
+        name,
+        visibility: options.visibility,
+        description: options.description,
+      });
+      data = response.data;
+    } else {
+      const response = await octokit.rest.repos.createForAuthenticatedUser({
+        name,
+        private: options.visibility === 'private',
+        description: options.description,
+      });
+      data = response.data;
+    }
+
+    const result: CreateRepoData = {
+      fullName: data.full_name,
+      url: data.html_url,
+      cloneUrl: data.clone_url,
+    };
+
+    emit({ type: 'init:repo:created', fullName: result.fullName, url: result.url });
+    return result;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    emit({ type: 'init:repo:failed', reason: message });
+    return fail(
+      'REPO_CREATE_FAILED',
+      `Failed to create repo "${owner}/${name}": ${message}`,
+      true,
+    );
+  }
+}
+
+/** Type guard: returns true if the result is a fail Result (not repo data) */
+export function isRepoResult(
+  result: CreateRepoData | InitResult,
+): result is InitResult {
+  return 'success' in result;
+}

--- a/packages/fleet/src/init/spec.ts
+++ b/packages/fleet/src/init/spec.ts
@@ -21,6 +21,9 @@ export type AuthMode = z.infer<typeof AuthModeSchema>;
 
 // ── INPUT ───────────────────────────────────────────────────────────
 
+export const VisibilitySchema = z.enum(['public', 'private']).default('private');
+export type Visibility = z.infer<typeof VisibilitySchema>;
+
 export const InitInputSchema = z.object({
   /** Repository in owner/repo format (auto-detected from git if omitted) */
   repo: z
@@ -41,6 +44,12 @@ export const InitInputSchema = z.object({
   intervalMinutes: z.number().min(5).default(360),
   /** Auth mode: 'token' uses secrets.GITHUB_TOKEN, 'app' generates a GitHub App token */
   auth: AuthModeSchema,
+  /** Whether to create the repo if it doesn't exist */
+  createRepo: z.boolean().default(false),
+  /** Repo visibility when creating (default: private) */
+  visibility: VisibilitySchema,
+  /** Repo description when creating */
+  description: z.string().optional(),
 });
 
 export type InitInput = z.infer<typeof InitInputSchema>;
@@ -49,6 +58,7 @@ export type InitInput = z.infer<typeof InitInputSchema>;
 
 export const InitErrorCode = z.enum([
   'REPO_NOT_FOUND',
+  'REPO_CREATE_FAILED',
   'BRANCH_CREATE_FAILED',
   'FILE_COMMIT_FAILED',
   'PR_CREATE_FAILED',
@@ -72,6 +82,8 @@ export interface InitSuccess {
     filesCreated: string[];
     /** Labels created in the repo */
     labelsCreated: string[];
+    /** Whether the repo was created as part of init */
+    repoCreated?: boolean;
   };
 }
 

--- a/packages/fleet/src/init/wizard/headless.ts
+++ b/packages/fleet/src/init/wizard/headless.ts
@@ -106,5 +106,13 @@ export async function validateHeadlessInputs(
     emit({ type: 'init:dry-run', files });
   }
 
-  return { owner, repo, baseBranch, authMethod, secretsToUpload, dryRun, overwrite: args.overwrite ?? false, features: parseFeatureFlags(args), intervalMinutes };
+  return {
+    owner, repo, baseBranch, authMethod, secretsToUpload, dryRun,
+    overwrite: args.overwrite ?? false,
+    features: parseFeatureFlags(args),
+    intervalMinutes,
+    createRepo: args['create-repo'],
+    visibility: (args.visibility === 'public' ? 'public' : 'private') as 'public' | 'private',
+    description: args.description,
+  };
 }

--- a/packages/fleet/src/init/wizard/types.ts
+++ b/packages/fleet/src/init/wizard/types.ts
@@ -28,6 +28,12 @@ export interface InitWizardResult {
   features?: Record<string, boolean>;
   /** Pipeline cadence in minutes (default 360 = 6h) */
   intervalMinutes: number;
+  /** Whether to create the repo if it doesn't exist */
+  createRepo?: boolean;
+  /** Repo visibility when creating (default: private) */
+  visibility?: 'public' | 'private';
+  /** Repo description when creating */
+  description?: string;
 }
 
 /** Parsed args from citty */
@@ -49,4 +55,10 @@ export interface InitArgs {
   interval?: string;
   /** Whether to overwrite existing workflow files */
   overwrite?: boolean;
+  /** Whether to create the repo if it doesn't exist */
+  'create-repo'?: boolean;
+  /** Repo visibility when creating */
+  visibility?: string;
+  /** Repo description when creating */
+  description?: string;
 }

--- a/packages/fleet/src/shared/cli/input.ts
+++ b/packages/fleet/src/shared/cli/input.ts
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+
+// ── SHARED INPUT ARGS ──────────────────────────────────────────────
+
+/**
+ * Common args for JSON input. Spread into any command's `args` definition
+ * alongside `outputArgs` for full agent-friendly IO.
+ */
+export const inputArgs = {
+  json: {
+    type: 'string' as const,
+    description: 'JSON payload matching the command schema. Replaces individual flags.',
+  },
+} as const;
+
+// ── RESOLVE INPUT ──────────────────────────────────────────────────
+
+/**
+ * Parse input from either a `--json` string or flag-built object through a Zod schema.
+ *
+ * - `--json` takes precedence when provided (agent path).
+ * - Falls back to `flagInput` (human path).
+ * - Both paths go through the same Zod validation.
+ *
+ * @param schema - Zod schema to validate against
+ * @param json - Raw JSON string from `--json` flag (agent input)
+ * @param flagInput - Object built from individual CLI flags (human input)
+ * @returns Parsed and validated input
+ */
+export function resolveInput<T>(
+  schema: { parse(data: unknown): T },
+  json?: string,
+  flagInput?: Record<string, unknown>,
+): T {
+  const raw = json ? JSON.parse(json) : flagInput;
+  return schema.parse(raw);
+}

--- a/packages/fleet/src/shared/events/init.ts
+++ b/packages/fleet/src/shared/events/init.ts
@@ -28,4 +28,9 @@ export type InitEvent =
   | { type: 'init:secret:uploaded'; name: string }
   | { type: 'init:secret:skipped'; name: string; reason: string }
   | { type: 'init:dry-run'; files: string[] }
-  | { type: 'init:already-initialized' };
+  | { type: 'init:already-initialized' }
+  // Repo creation events
+  | { type: 'init:repo:creating'; owner: string; name: string }
+  | { type: 'init:repo:created'; fullName: string; url: string }
+  | { type: 'init:repo:exists'; fullName: string }
+  | { type: 'init:repo:failed'; reason: string };

--- a/packages/fleet/tsconfig.test.json
+++ b/packages/fleet/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
- Add createRepo op with org/user detection and GitHub REST API
- Extend InitInputSchema with createRepo, visibility, description fields
- Wire --create-repo, --visibility, --description, --json flags into CLI
- Add resolveInput utility with structural parser type (no ZodType generic)
- Add init:repo:* lifecycle events
- Add tsconfig.test.json for IDE module resolution in __tests__
- 25 new tests across 4 test files (715 total, 0 failures)