### PR TITLE
fix(fleet): include audit subcommands in build + migrate to shared ou…

### DIFF
--- a/packages/fleet/build.ts
+++ b/packages/fleet/build.ts
@@ -45,6 +45,7 @@ import { writeFileSync } from 'fs';
 const cliEntrypoints = [
   './src/cli/index.ts',
   ...globSync('./src/cli/*.command.ts'),
+  ...globSync('./src/cli/audit/*.subcommand.ts'),
 ];
 
 await Bun.build({

--- a/packages/fleet/src/__tests__/audit-discovery.test.ts
+++ b/packages/fleet/src/__tests__/audit-discovery.test.ts
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const auditDir = join(__dirname, '..', 'cli', 'audit');
+
+describe('Audit subcommand discovery', () => {
+  it('audit directory exists with subcommand files', () => {
+    expect(existsSync(auditDir)).toBe(true);
+  });
+
+  it('discovers scan, inspect, and list subcommand files', () => {
+    const files = readdirSync(auditDir);
+    const subcommandNames = files
+      .filter((f) => f.endsWith('.subcommand.ts'))
+      .map((f) => f.replace('.subcommand.ts', ''));
+
+    expect(subcommandNames).toContain('scan');
+    expect(subcommandNames).toContain('inspect');
+    expect(subcommandNames).toContain('list');
+  });
+
+  it('subcommand files export a default citty command', async () => {
+    const subcommandFiles = readdirSync(auditDir).filter((f) =>
+      f.endsWith('.subcommand.ts'),
+    );
+
+    for (const file of subcommandFiles) {
+      const mod = await import(join(auditDir, file));
+      expect(mod.default).toBeDefined();
+      expect(mod.default.meta).toBeDefined();
+      expect(mod.default.meta.name).toBeTruthy();
+    }
+  });
+});

--- a/packages/fleet/src/audit/ops/inspect-lineage.ts
+++ b/packages/fleet/src/audit/ops/inspect-lineage.ts
@@ -1,0 +1,88 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Octokit } from 'octokit';
+import { buildLineage } from '../graph/build-lineage.js';
+import { nodeKey } from '../graph/types.js';
+
+/** Serialized lineage node for JSON output. */
+export interface SerializedLineageNode {
+  key: string;
+  ref: { kind: string; id: string };
+  edges: number;
+  data: { title: unknown; state: unknown };
+}
+
+/** Serialized lineage graph for JSON output. */
+export interface InspectResult {
+  root: { kind: string; id: string };
+  nodes: SerializedLineageNode[];
+  unresolvedEdges: Array<{ from: { kind: string; id: string }; expectedRelation: string; reason: string }>;
+}
+
+/**
+ * Inspect the lineage graph for a specific issue or PR.
+ *
+ * Returns a serializable result (no Maps or complex types) that can
+ * be rendered as JSON via `renderResult` or printed in human format.
+ */
+export async function inspectLineage(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  target: { kind: 'issue' | 'pr'; id: string },
+  options: { depth: number } = { depth: 2 },
+): Promise<InspectResult> {
+  const graph = await buildLineage(
+    { octokit },
+    owner,
+    repo,
+    target,
+    options,
+  );
+
+  return {
+    root: graph.root,
+    nodes: Array.from(graph.nodes.entries()).map(([key, node]) => ({
+      key,
+      ref: node.ref,
+      edges: node.edges.length,
+      data: { title: node.data.title, state: node.data.state },
+    })),
+    unresolvedEdges: graph.unresolvedEdges,
+  };
+}
+
+/** Render an InspectResult as human-readable text. */
+export function renderInspectHuman(result: InspectResult): string {
+  const lines: string[] = [];
+  lines.push(`\n🌳 Lineage Graph (root: ${result.root.kind}:${result.root.id})`);
+  lines.push(`   Nodes: ${result.nodes.length}`);
+  lines.push(`   Unresolved edges: ${result.unresolvedEdges.length}`);
+
+  for (const node of result.nodes) {
+    const title = (node.data.title as string) || node.ref.id;
+    lines.push(`\n   ${node.key}: ${title}`);
+    lines.push(`     edges: ${node.edges}`);
+  }
+
+  if (result.unresolvedEdges.length > 0) {
+    lines.push(`\n   ⚠️  Unresolved Edges:`);
+    for (const edge of result.unresolvedEdges) {
+      lines.push(`     ${edge.from.kind}:${edge.from.id} --${edge.expectedRelation}--> ? (${edge.reason})`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/packages/fleet/src/cli/audit/inspect.subcommand.ts
+++ b/packages/fleet/src/cli/audit/inspect.subcommand.ts
@@ -15,15 +15,16 @@
 import { defineCommand } from 'citty';
 import { createFleetOctokit } from '../../shared/auth/octokit.js';
 import { getGitRepoInfo } from '../../shared/auth/git.js';
-import { buildLineage } from '../../audit/graph/build-lineage.js';
-import { nodeKey } from '../../audit/graph/types.js';
+import { outputArgs, renderResult, resolveOutputFormat } from '../../shared/cli/output.js';
+import { inspectLineage, renderInspectHuman } from '../../audit/ops/inspect-lineage.js';
 
 /**
  * `audit inspect` — Show lineage graph for a specific item.
  *
  * Examples:
- *   jules-fleet audit inspect issue 42    # Lineage graph for issue #42
- *   jules-fleet audit inspect pr 99       # Lineage graph for PR #99
+ *   jules-fleet audit inspect issue 42                       # Human-readable graph
+ *   jules-fleet audit inspect issue 42 --output json         # JSON output
+ *   jules-fleet audit inspect pr 99 --output json --fields root,nodes
  */
 export default defineCommand({
   meta: {
@@ -46,21 +47,18 @@ export default defineCommand({
       description: 'Max traversal depth (default: 2)',
       default: '2',
     },
-    json: {
-      type: 'boolean',
-      description: 'Output as JSON',
-      default: false,
-    },
+    ...outputArgs,
     owner: {
       type: 'string',
-      description: 'Repository owner',
+      description: 'Repository owner (auto-detected from git remote if omitted)',
     },
     repo: {
       type: 'string',
-      description: 'Repository name',
+      description: 'Repository name (auto-detected from git remote if omitted)',
     },
   },
   async run({ args }) {
+    // Resolve owner/repo
     let owner = args.owner;
     let repo = args.repo;
     if (!owner || !repo) {
@@ -69,49 +67,19 @@ export default defineCommand({
       repo = repo || repoInfo.repo;
     }
 
+    // Execute via ops module
     const kind = args.type === 'pr' ? 'pr' : 'issue';
     const octokit = createFleetOctokit();
+    const data = await inspectLineage(octokit, owner, repo, { kind, id: args.id }, { depth: Number(args.depth) });
 
-    const graph = await buildLineage(
-      { octokit },
-      owner,
-      repo,
-      { kind, id: args.id },
-      { depth: Number(args.depth) },
-    );
-
-    if (args.json) {
-      const serialized = {
-        root: graph.root,
-        nodes: Array.from(graph.nodes.entries()).map(([key, node]) => ({
-          key,
-          ref: node.ref,
-          edges: node.edges.length,
-          data: { title: node.data.title, state: node.data.state },
-        })),
-        unresolvedEdges: graph.unresolvedEdges,
-      };
-      console.log(JSON.stringify(serialized, null, 2));
+    // Render output
+    const format = resolveOutputFormat(args);
+    const result = { success: true as const, data };
+    const json = renderResult(result, format, args.fields as string | undefined);
+    if (json !== null) {
+      console.log(json);
     } else {
-      console.log(`\n🌳 Lineage Graph (root: ${nodeKey(graph.root)})`);
-      console.log(`   Nodes: ${graph.nodes.size}`);
-      console.log(`   Unresolved edges: ${graph.unresolvedEdges.length}`);
-
-      for (const [key, node] of graph.nodes) {
-        const title = (node.data.title as string) || node.ref.id;
-        console.log(`\n   ${key}: ${title}`);
-        for (const edge of node.edges) {
-          const status = edge.resolved ? '→' : '⚠';
-          console.log(`     ${status} ${edge.relation} → ${nodeKey(edge.target)}`);
-        }
-      }
-
-      if (graph.unresolvedEdges.length > 0) {
-        console.log(`\n   ⚠️  Unresolved Edges:`);
-        for (const edge of graph.unresolvedEdges) {
-          console.log(`     ${nodeKey(edge.from)} --${edge.expectedRelation}--> ? (${edge.reason})`);
-        }
-      }
+      console.log(renderInspectHuman(data));
     }
   },
 });

--- a/packages/fleet/src/cli/audit/list.subcommand.ts
+++ b/packages/fleet/src/cli/audit/list.subcommand.ts
@@ -16,6 +16,7 @@ import { defineCommand } from 'citty';
 import { createFleetOctokit } from '../../shared/auth/octokit.js';
 import { getGitRepoInfo } from '../../shared/auth/git.js';
 import { listUndispatchedIssues } from '../../audit/ops/list-undispatched-issues.js';
+import { outputArgs, renderResult, resolveOutputFormat } from '../../shared/cli/output.js';
 
 /**
  * `audit list` — Query operations.
@@ -39,11 +40,7 @@ export default defineCommand({
       description: 'Filter to undispatched fleet issues',
       default: false,
     },
-    json: {
-      type: 'boolean',
-      description: 'Output as JSON',
-      default: false,
-    },
+    ...outputArgs,
     owner: {
       type: 'string',
       description: 'Repository owner',
@@ -66,8 +63,11 @@ export default defineCommand({
 
     if (args.type === 'issues' && args.undispatched) {
       const issues = await listUndispatchedIssues(octokit, owner, repo);
-      if (args.json) {
-        console.log(JSON.stringify(issues, null, 2));
+      const format = resolveOutputFormat(args);
+      const result = { success: true as const, data: { issues } };
+      const json = renderResult(result, format, args.fields as string | undefined);
+      if (json !== null) {
+        console.log(json);
       } else {
         console.log(`\n📋 Undispatched Fleet Issues (${issues.length}):`);
         for (const issue of issues) {


### PR DESCRIPTION
…tputArgs

- Add audit/*.subcommand.ts to build.ts CLI entrypoints so they're included in dist/ and discovered by dynamic import
- Migrate list and inspect subcommands from ad-hoc --json boolean to shared outputArgs (--output json + --fields) for agent context window discipline
- Add audit discovery regression test