### PR TITLE
Fixes #188: Add practical Basic Session example to SDK

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,6 +4,10 @@
 
 Orchestrate complex, long-running coding tasks to an ephemeral cloud environment integrated with a GitHub repo.
 
+## Examples
+
+- [Basic Session](./examples/basic-session/README.md)
+
 ## Send work to a Cloud based session
 
 ```ts

--- a/packages/core/examples/basic-session/README.md
+++ b/packages/core/examples/basic-session/README.md
@@ -1,0 +1,36 @@
+# Basic Session Example
+
+This example demonstrates how to use the Jules SDK to create a simple interactive session. It will use the `jules.session` method to connect to the Jules API, create a session without a specific repository context (a "Repoless" session), provide a prompt to an AI agent, and wait for the results.
+
+## Requirements
+
+- Node.js >= 18 or Bun
+- A Jules API Key (`JULES_API_KEY` environment variable)
+
+## Setup
+
+1. Make sure you have installed the SDK dependencies in the project root.
+
+2. Export your Jules API key:
+
+```bash
+export JULES_API_KEY="your-api-key-here"
+```
+
+## Running the Example
+
+Using `bun`:
+
+```bash
+bun run index.ts
+```
+
+Using `npm` and `tsx` (or similar TypeScript runner):
+
+```bash
+npx tsx index.ts
+```
+
+## What it does
+
+The script creates a session using `jules.session` and asks the agent to write a haiku. It then waits for the result and retrieves the output. This is a basic demonstration of the isolated core Jules API.

--- a/packages/core/examples/basic-session/index.ts
+++ b/packages/core/examples/basic-session/index.ts
@@ -1,0 +1,75 @@
+import { jules } from '@google/jules-sdk';
+
+/**
+ * Basic Session Example
+ *
+ * Demonstrates a simple interaction with the Jules SDK.
+ * It creates a repoless session (no GitHub source), provides a simple prompt,
+ * and awaits the final outcome.
+ */
+async function main() {
+  // Ensure the JULES_API_KEY environment variable is set.
+  if (!process.env.JULES_API_KEY) {
+    console.error('Error: JULES_API_KEY environment variable is not set.');
+    console.error('Please set it using: export JULES_API_KEY="your-api-key"');
+    process.exit(1);
+  }
+
+  console.log('Creating a new Jules session...');
+
+  try {
+    // 1. Create a basic session
+    // We use a repoless session (no source) for this simple demonstration.
+    const session = await jules.session({
+      prompt: 'Write a haiku about artificial intelligence programming itself.',
+    });
+
+    console.log(`Session created! ID: ${session.id}`);
+    console.log('Waiting for the agent to complete the task...');
+
+    // 2. Await the result of the session
+    // This will poll the API until the session reaches a terminal state (completed or failed).
+    const outcome = await session.result();
+
+    console.log('\n--- Session Result ---');
+    console.log(`State: ${outcome.state}`);
+
+    if (outcome.state === 'completed') {
+      // 3. Retrieve and display the final message from the agent
+      // Since it's a haiku, we expect it in the generated files or the agent's messages.
+      // Often, the agent writes its final output to a file or answers in a message.
+      // Let's print out the latest agent message.
+      const activities = await jules.select({
+          from: 'activities',
+          where: { type: 'agentMessaged', 'session.id': session.id },
+          order: 'desc',
+          limit: 1,
+      });
+
+      if (activities.length > 0) {
+        console.log('\nAgent Message:');
+        console.log(activities[0].message);
+      } else {
+        console.log('\nThe agent did not leave a final message.');
+
+        // Let's check generated files
+        const files = outcome.generatedFiles();
+        if (files.size > 0) {
+            console.log('\nGenerated Files:');
+            for (const [filename, content] of files.entries()) {
+                console.log(`\nFile: ${filename}`);
+                console.log(content.content);
+            }
+        }
+      }
+    } else {
+      console.error('The session did not complete successfully.');
+    }
+
+  } catch (error) {
+    console.error('An error occurred during the session:', error);
+  }
+}
+
+// Run the example
+main();


### PR DESCRIPTION
Fixes #188

This PR introduces a new "Basic Session" example to the Jules TypeScript SDK `examples/` directory. This acts as an isolated, runnable demonstration of the core API exported from `@google/jules-sdk`.

**Changes included:**
- Created `packages/core/examples/basic-session/index.ts` containing the code to initialize the client, start a repoless session using `jules.session()`, provide a simple prompt, and log the finalized result.
- Created `packages/core/examples/basic-session/README.md` containing prerequisite setup instructions and execution commands.
- Updated `packages/core/README.md` to feature a link to the new Basic Session example under a new `## Examples` header.

---
*PR created automatically by Jules for task [9874022629945074](https://jules.google.com/task/9874022629945074) started by @davideast*