### PR TITLE
fix(fleet): prevent cascading duplicate PRs in fleet-merge workflow

### DIFF
--- a/.github/workflows/fleet-merge.yml
+++ b/.github/workflows/fleet-merge.yml
@@ -6,9 +6,6 @@ name: Fleet Merge
 on:
   schedule:
     - cron: '0 */3 * * *'
-  workflow_run:
-    workflows: ['Conflict Detection']
-    types: [completed]
   workflow_dispatch:
     inputs:
       mode:
@@ -29,7 +26,7 @@ on:
 
 concurrency:
   group: fleet-merge
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   merge:

--- a/packages/fleet/package.json
+++ b/packages/fleet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/jules-fleet",
-  "version": "0.0.1-experimental.31",
+  "version": "0.0.1-experimental.32",
   "type": "module",
   "description": "Fleet orchestration tools for Jules — analyze, dispatch, merge, init, configure",
   "repository": {

--- a/packages/fleet/src/__tests__/helpers/merge-test-harness.ts
+++ b/packages/fleet/src/__tests__/helpers/merge-test-harness.ts
@@ -116,6 +116,7 @@ export class MergeTestHarness {
       pullsGet: ReturnType<typeof vi.fn>;
       pullsUpdate: ReturnType<typeof vi.fn>;
       julesSession: ReturnType<typeof vi.fn>;
+      listComments: ReturnType<typeof vi.fn>;
     };
   } {
     const events: FleetEvent[] = [];
@@ -224,6 +225,7 @@ export class MergeTestHarness {
         },
         issues: {
           createComment: vi.fn().mockResolvedValue({ data: {} }),
+          listComments: vi.fn().mockResolvedValue({ data: [] }),
         },
       },
       graphql: vi.fn().mockResolvedValue({
@@ -257,6 +259,7 @@ export class MergeTestHarness {
         pullsGet: pullsGetMock,
         pullsUpdate: pullsUpdateMock,
         julesSession: this.julesSessionMock,
+        listComments: octokit.rest.issues.listComments,
       },
     };
   }

--- a/packages/fleet/src/__tests__/merge-handler-scenarios.test.ts
+++ b/packages/fleet/src/__tests__/merge-handler-scenarios.test.ts
@@ -167,6 +167,35 @@ describe('Independent PR scenarios', () => {
       expect(result.data.redispatched.some((r) => r.oldPr === 1)).toBe(true);
     }
   });
+
+  // Regression: redispatch dedup guard — prevents cascading PR creation.
+  // When a PR was already redispatched recently (has a comment with the marker),
+  // the handler should skip creating a new Jules session.
+  it('1.9: conflict + recent redispatch comment → skipped, no new session', async () => {
+    const { handler, mocks } = new MergeTestHarness()
+      .withPRs([1])
+      .updateBranchResult(1, 'conflict')
+      .build();
+
+    // Simulate a recent redispatch comment on the PR
+    mocks.listComments.mockResolvedValue({
+      data: [{
+        body: '⚠️ Closed by fleet-merge: merge conflict detected. Task re-dispatched.',
+        created_at: new Date().toISOString(), // recent
+      }],
+    });
+
+    const result = await handler.execute({ ...BASE_INPUT, redispatch: true });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Should NOT have created a new Jules session
+      expect(mocks.julesSession).not.toHaveBeenCalled();
+      // PR should be skipped, not redispatched
+      expect(result.data.redispatched).toHaveLength(0);
+      expect(result.data.skipped).toContain(1);
+    }
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════

--- a/packages/fleet/src/__tests__/merge-template.test.ts
+++ b/packages/fleet/src/__tests__/merge-template.test.ts
@@ -109,6 +109,18 @@ describe('buildMergeTemplate', () => {
     );
     expect(runStep.env.GITHUB_TOKEN).toContain('secrets.GITHUB_TOKEN');
   });
+
+  // Regression: workflow_run trigger creates a feedback loop —
+  // redispatched PRs trigger Conflict Detection → Fleet Merge → more redispatches.
+  it('does NOT include a workflow_run trigger', () => {
+    const parsed = yaml.parse(template.content);
+    expect(parsed.on.workflow_run).toBeUndefined();
+  });
+
+  it('sets cancel-in-progress to true', () => {
+    const parsed = yaml.parse(template.content);
+    expect(parsed.concurrency['cancel-in-progress']).toBe(true);
+  });
 });
 
 describe('buildMergeTemplate with auth=app', () => {

--- a/packages/fleet/src/init/templates/merge.ts
+++ b/packages/fleet/src/init/templates/merge.ts
@@ -29,9 +29,6 @@ name: Fleet Merge
 on:
   schedule:
     - cron: '${cron}'
-  workflow_run:
-    workflows: ['Conflict Detection']
-    types: [completed]
   workflow_dispatch:
     inputs:
       mode:
@@ -52,7 +49,7 @@ on:
 
 concurrency:
   group: fleet-merge
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   merge:

--- a/packages/fleet/src/merge/handler.ts
+++ b/packages/fleet/src/merge/handler.ts
@@ -162,7 +162,7 @@ export class MergeHandler implements MergeSpec {
               } else {
                 // Fall back to per-PR redispatch
                 for (const pr of failedPRs) {
-                  await redispatch(
+                  const rdResult = await redispatch(
                     this.octokit,
                     input.owner,
                     input.repo,
@@ -172,7 +172,9 @@ export class MergeHandler implements MergeSpec {
                     this.emit,
                     this.sleep,
                   );
-                  redispatched.push({ oldPr: pr.number });
+                  if (!rdResult.skipped) {
+                    redispatched.push({ oldPr: pr.number });
+                  }
                   skipped.push(pr.number);
                 }
               }
@@ -230,7 +232,7 @@ export class MergeHandler implements MergeSpec {
               );
             }
 
-            await redispatch(
+            const rdResult = await redispatch(
               this.octokit,
               input.owner,
               input.repo,
@@ -241,9 +243,11 @@ export class MergeHandler implements MergeSpec {
               this.sleep,
             );
 
-            redispatched.push({
-              oldPr: currentPr.number,
-            });
+            if (!rdResult.skipped) {
+              redispatched.push({
+                oldPr: currentPr.number,
+              });
+            }
             skipped.push(currentPr.number);
             break;
           }
@@ -426,10 +430,12 @@ export class MergeHandler implements MergeSpec {
           this.emit,
           this.sleep,
         );
+        if (result.skipped) {
+          return { merged: false };
+        }
         return {
           merged: false,
           redispatched: true,
-          sessionId: result?.number?.toString(),
         };
       }
       return { merged: false };

--- a/packages/fleet/src/merge/ops/redispatch.ts
+++ b/packages/fleet/src/merge/ops/redispatch.ts
@@ -18,9 +18,14 @@ import type { FleetEmitter } from '../../shared/events.js';
 import { jules } from '@google/jules-sdk';
 import { getClosingIssueRefs } from './extract-issue-refs.js';
 
+export interface RedispatchResult {
+  /** True if skip was due to dedup guard (recent redispatch detected) */
+  skipped: boolean;
+}
+
 /**
  * Closes a conflicting PR and re-dispatches via Jules SDK.
- * Polls for the new PR and returns it, or null on timeout.
+ * Returns { skipped: true } if a dedup guard prevents redispatch.
  */
 export async function redispatch(
   octokit: Octokit,
@@ -31,7 +36,13 @@ export async function redispatch(
   pollTimeoutSeconds: number,
   emit: FleetEmitter,
   sleep: (ms: number) => Promise<void>,
-): Promise<PR | null> {
+): Promise<RedispatchResult> {
+  // Dedup guard: skip if this PR was already redispatched recently
+  if (await wasRecentlyRedispatched(octokit, owner, repo, oldPr.number)) {
+    emit({ type: 'merge:redispatch:skipped', oldPr: oldPr.number, reason: 'recent-redispatch' } as any);
+    return { skipped: true };
+  }
+
   emit({ type: 'merge:redispatch:start', oldPr: oldPr.number });
 
   // Close the conflicting PR
@@ -74,7 +85,7 @@ export async function redispatch(
       sessionId: session.id,
     });
 
-    return null;
+    return { skipped: false };
   } catch (error) {
     emit({
       type: 'error',
@@ -83,7 +94,7 @@ export async function redispatch(
     });
   }
 
-  return null;
+  return { skipped: false };
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────
@@ -200,3 +211,37 @@ function buildRedispatchContext(
   return lines.join('\n');
 }
 
+// ── Dedup Guard ──────────────────────────────────────────────────────
+
+/** Cooldown window: skip redispatch if one occurred within this many ms */
+const REDISPATCH_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+
+/** Redispatch marker found in PR body when fleet-merge closes a PR */
+const REDISPATCH_MARKER = '⚠️ Closed by fleet-merge';
+
+/**
+ * Checks whether a PR was recently redispatched by scanning its comments
+ * for the redispatch marker. Returns true if a recent marker is found.
+ */
+async function wasRecentlyRedispatched(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<boolean> {
+  try {
+    const { data: comments } = await octokit.rest.issues.listComments({
+      owner,
+      repo,
+      issue_number: prNumber,
+    });
+    const now = Date.now();
+    return comments.some((c: any) => {
+      if (!c.body?.includes(REDISPATCH_MARKER)) return false;
+      const commentTime = new Date(c.created_at).getTime();
+      return now - commentTime < REDISPATCH_COOLDOWN_MS;
+    });
+  } catch {
+    return false; // Non-fatal — assume no prior redispatch
+  }
+}


### PR DESCRIPTION
- Remove workflow_run trigger from merge template (breaks feedback loop)
- Change cancel-in-progress to true (prevents stacked runs)
- Add redispatch dedup guard with 1-hour cooldown (wasRecentlyRedispatched)
- Update live fleet-merge.yml with same fixes
- Bump version to 0.0.1-experimental.32

Closes cascading PR creation caused by:
  Conflict Detection → workflow_run → Fleet Merge → redispatch → new PR → repeat