### PR TITLE
fix(core): export paginated REST response interfaces

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -437,6 +437,30 @@ export interface SessionResource {
   archived: boolean;
 }
 
+/**
+ * Paginated REST API response for listing sessions.
+ */
+export interface ListSessionsResponse {
+  sessions: SessionResource[];
+  nextPageToken?: string;
+}
+
+/**
+ * Paginated REST API response for listing sources.
+ */
+export interface ListSourcesResponse {
+  sources: Source[];
+  nextPageToken?: string;
+}
+
+/**
+ * Paginated REST API response for listing activities.
+ */
+export interface ListActivitiesResponse {
+  activities: Activity[];
+  nextPageToken?: string;
+}
+
 // -----------------------------------------------------------------------------
 // Activity and Artifact Types
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add public pagination response interfaces to `packages/core/src/types.ts`:

- `ListSessionsResponse`
- `ListSourcesResponse`
- `ListActivitiesResponse`

Each interface includes the resource array and optional `nextPageToken`.

## Context

This aligns the SDK type surface with the Jules REST API pagination schema.

## Testing

- Attempted `npm --workspace packages/core run type-check`
- Could not complete type-check in the current local environment because workspace dependencies are not fully installed
